### PR TITLE
Googletest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,9 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+
+#
+# Project-specific gitignore
+#
+
+tests/googletest

--- a/.gitignore
+++ b/.gitignore
@@ -114,4 +114,5 @@ fabric.properties
 # Project-specific gitignore
 #
 
+# googletest can be cloned from github: git clone https://github.com/google/googletest.git
 tests/googletest

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+battleship-tests

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="CMakeWorkspace" PROJECT_DIR="$PROJECT_DIR$" />
+  <component name="CMakeWorkspace" PROJECT_DIR="$PROJECT_DIR$/tests">
+    <contentRoot DIR="$PROJECT_DIR$" />
+  </component>
 </project>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ file(GLOB SOURCE_FILES CONFIGURE_DEPENDS
         "src/**/*.cpp")
 
 add_executable(battleship ${SOURCE_FILES})
-
+add_subdirectory(tests)
 
 # Add SFML
 include_directories(src include C:/SFML/include)

--- a/README.md
+++ b/README.md
@@ -2,12 +2,17 @@
 
 Group project for my Fundamentals of Software Development course
 
-Note: This repository works, but is undergoing heavy refactoring, espcially the screen .cpp files
+Note: This repository works, but is undergoing heavy refactoring, especially the screen .cpp files
 
 ### Troubleshooting
 
-**I can't run the project or the tests?** You need to load the correct CMakeLists.txt file. To run the program itself, load the Cmake in the root directory. To run tests, load the Cmake in the tests/ folder
+**I can't run the project or the tests?** You need to load the correct CMakeLists.txt file. To 
+run the program itself, load the Cmake in the root directory. To run tests, load the Cmake in 
+the tests/ folder
 
-**Issues with running tests or anything about googletest not being found:** Open tests/ and do ```git clone https://github.com/google/googletest.git```. The googletests repo is not included in thie repo's VCS because it it not necessary (similar to node_modules- it only take one command and a few seconds to get it, and greatly reduces the repository size)
+**Issues with running tests or anything about googletest not being found:** Open tests/ and do 
+```git clone https://github.com/google/googletest.git```. The googletests repo is not included 
+in the repo's VCS because it is not necessary (similar to node_modules- it only takes one command 
+and a few seconds to get it, and greatly reduces the repository size)
 
 **Cannot find file while compiling:** Your compiler working directory needs to be the build/ folder

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 enable_testing()
 add_subdirectory(googletest)
+include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
 
 file(GLOB TEST_FILES CONFIGURE_DEPENDS
         "../include/*.hpp"

--- a/tests/architecture/structure.cpp
+++ b/tests/architecture/structure.cpp
@@ -3,7 +3,7 @@
  * any deleted or renamed required files
  */
 
-#include <gtest/gtest.hpp>
+#include <gtest/gtest.h>
 #include <sys/stat.h>
 
 using std::string;

--- a/tests/architecture/structure.cpp
+++ b/tests/architecture/structure.cpp
@@ -20,7 +20,7 @@ TEST(Architecture, requiredFiles) {
 
             // Test files
             "tests/CMakeLists.txt", "tests/googletest", "tests/main.cpp",
-            "tests/assertions.h", "tests/unit", "tests/integration", "tests/system",
+            "tests/assertions.hpp", "tests/unit", "tests/integration", "tests/system",
 
             // VCS files
             ".git", ".gitignore", "README.md", "LICENSE"};


### PR DESCRIPTION
Fixed up googletest: updated it based on the .h to .hpp changes and included it as a subdirectory in the main CMakeLists (so the linter stops complaining)