### PR TITLE
Add images managers

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <option name="RIGHT_MARGIN" value="100" />
     <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="true" />
     <clangFormatSettings>
       <option name="ENABLED" value="true" />

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Note: This repository works, but is undergoing heavy refactoring, especially the
 
 ### Troubleshooting
 
-**I can't run the project or the tests?** You need to load the correct CMakeLists.txt file. To 
-run the program itself, load the Cmake in the root directory. To run tests, load the Cmake in 
-the tests/ folder
+**I can't run the project or the tests?** You need to load the correct CMakeLists.txt file. To run
+the program itself, load the Cmake in the root directory. To run tests, load the Cmake in the tests/
+folder
 
-**Issues with running tests or anything about googletest not being found:** Open tests/ and do 
-```git clone https://github.com/google/googletest.git```. The googletests repo is not included 
-in the repo's VCS because it is not necessary (similar to node_modules- it only takes one command 
-and a few seconds to get it, and greatly reduces the repository size)
+**Issues with running tests or anything about googletest not being found:** Open tests/ and do
+```git clone https://github.com/google/googletest.git```. The googletests repo is not included in
+the repo's VCS because it is not necessary (similar to node_modules- it only takes one command and a
+few seconds to get it, and greatly reduces the repository size)
 
 **Cannot find file while compiling:** Your compiler working directory needs to be the build/ folder

--- a/src/controllers/screenManager.cpp
+++ b/src/controllers/screenManager.cpp
@@ -3,7 +3,6 @@
  */
 
 #include "screenManager.hpp"
-
 #include "../screens/difficultySelection.hpp"
 #include "../screens/fleetPlacement.hpp"
 #include "../screens/gameModeSelection.hpp"

--- a/src/controllers/screenManager.hpp
+++ b/src/controllers/screenManager.hpp
@@ -6,8 +6,8 @@
 #ifndef BATTLESHIP_SCREENMANAGER_H
 #define BATTLESHIP_SCREENMANAGER_H
 
-#include "state.hpp"
 #include "../controllers/screenTemplate.hpp"
+#include "state.hpp"
 #include <map>
 
 namespace screen {
@@ -29,6 +29,6 @@ namespace screen {
          */
         std::map<Screens, ScreenTemplate *> screenList;
     };
-}// namespace screens
+}// namespace screen
 
 #endif// BATTLESHIP_SCREENMANAGER_H

--- a/src/controllers/screenTemplate.cpp
+++ b/src/controllers/screenTemplate.cpp
@@ -7,3 +7,9 @@
 using screen::ScreenTemplate;
 
 ScreenTemplate::ScreenTemplate() = default;
+
+void screen::ScreenTemplate::run() {
+    this->update();
+    this->poll();
+    this->render();
+}

--- a/src/controllers/screenTemplate.hpp
+++ b/src/controllers/screenTemplate.hpp
@@ -39,7 +39,7 @@ namespace screen {
         /**
          * All the textures and sprites for this screen
          */
-        ScreenResourceManager images;
+        ScreenResourceManager resources;
 
         /**
          *

--- a/src/controllers/screenTemplate.hpp
+++ b/src/controllers/screenTemplate.hpp
@@ -5,7 +5,7 @@
 #ifndef BATTLESHIP_SCREENTEMPLATE_H
 #define BATTLESHIP_SCREENTEMPLATE_H
 
-#include "../helpers/ImagesManager.hpp"
+#include "../helpers/ScreenResourceManager.hpp"
 #include "state.hpp"
 #include <SFML/System.hpp>
 
@@ -39,7 +39,7 @@ namespace screen {
         /**
          * All the textures and sprites for this screen
          */
-        ImagesManager images;
+        ScreenResourceManager images;
 
         /**
          *

--- a/src/controllers/screenTemplate.hpp
+++ b/src/controllers/screenTemplate.hpp
@@ -18,7 +18,7 @@ namespace screen {
         /**
          * Renders this screens to the GUI
          */
-        virtual void run() = 0;
+        void run();
 
         /**
          * Copy constructor for heap memory
@@ -40,6 +40,21 @@ namespace screen {
          * All the textures and sprites for this screen
          */
         ImagesManager images;
+
+        /**
+         *
+         */
+        virtual void update() = 0;
+
+        /**
+         *
+         */
+        virtual void poll() = 0;
+
+        /**
+         *
+         */
+        virtual void render() = 0;
     };
 
 }// namespace screen

--- a/src/controllers/state.hpp
+++ b/src/controllers/state.hpp
@@ -116,7 +116,6 @@ private:
      * makes going back easier and less buggy
      */
     static Screens previous;
-
 };
 
 #endif// BATTLESHIP_STATE_H

--- a/src/entity/button.cpp
+++ b/src/entity/button.cpp
@@ -7,7 +7,7 @@
 
 using entity::Button;
 
-Button::Button(sf::Vector2f position, sf::Vector2f scale, sf::Texture &idleTexture, sf::Texture &activeTexture) {
+Button::Button(const sf::Vector2f position, const sf::Vector2f scale, sf::Texture &idleTexture, sf::Texture &activeTexture) {
     this->active = false;
     this->idleTexture = &idleTexture;
     this->activeTexture = &activeTexture;

--- a/src/entity/button.cpp
+++ b/src/entity/button.cpp
@@ -1,18 +1,18 @@
 /**
- * File: button.cpp
- * Description: Front-end class that creates buttons and manages button states, textures, and sprites
+ * Front-end class that creates buttons and manages button states, textures, and sprites
  */
 
 #include "button.hpp"
+#include <memory>
 
 using entity::Button;
 
 Button::Button(const sf::Vector2f position, const sf::Vector2f scale, sf::Texture &idleTexture, sf::Texture &activeTexture) {
     this->active = false;
-    this->idleTexture = &idleTexture;
-    this->activeTexture = &activeTexture;
+    this->idleTexture.reset(&idleTexture);
+    this->activeTexture.reset(&activeTexture);
 
-    this->sprite = new sf::Sprite(*this->idleTexture);
+    this->sprite = std::make_unique<sf::Sprite>(*this->idleTexture);
     this->sprite->setPosition(position);
     this->sprite->setScale(scale);
 }
@@ -32,30 +32,5 @@ void Button::updateButtonState(const sf::Vector2f mousePosition) {
     } else {
         this->active = false;
         this->sprite->setTexture(*this->idleTexture);
-    }
-}
-
-Button::Button(const Button &source) {
-    this->active = source.active;
-    this->idleTexture = source.idleTexture;
-    this->activeTexture = source.activeTexture;
-    this->sprite = source.sprite;
-}
-
-Button::~Button() {
-    delete idleTexture;
-    delete activeTexture;
-    delete sprite;
-}
-
-Button &Button::operator=(const Button &source) {
-    if (this == &source) {
-        return *this;
-    } else {
-        this->active = source.active;
-        this->idleTexture = source.idleTexture;
-        this->activeTexture = source.activeTexture;
-        this->sprite = source.sprite;
-        return *this;
     }
 }

--- a/src/entity/button.cpp
+++ b/src/entity/button.cpp
@@ -7,7 +7,7 @@
 
 using entity::Button;
 
-Button::Button(sf::Vector2f position, sf::Vector2f scale, sf::Texture& idleTexture, sf::Texture& activeTexture) {
+Button::Button(sf::Vector2f position, sf::Vector2f scale, sf::Texture &idleTexture, sf::Texture &activeTexture) {
     this->active = false;
     this->idleTexture = &idleTexture;
     this->activeTexture = &activeTexture;
@@ -26,7 +26,7 @@ void Button::render(sf::RenderWindow &window) const {
 }
 
 void Button::updateButtonState(const sf::Vector2f mousePosition) {
-    if (this->sprite->getGlobalBounds().contains(mousePosition)) { // Mouse is on the button
+    if (this->sprite->getGlobalBounds().contains(mousePosition)) {// Mouse is on the button
         this->active = true;
         this->sprite->setTexture(*this->activeTexture);
     } else {

--- a/src/entity/button.hpp
+++ b/src/entity/button.hpp
@@ -37,26 +37,21 @@ namespace entity {
          */
         void updateButtonState(sf::Vector2f mousePosition);
 
-        // Big three
-        Button(const Button &source);
-        ~Button();
-        Button &operator=(const Button &source);
-
     private:
         /**
          * Texture when the button does not have the mouse over it
          */
-        sf::Texture *idleTexture;
+        std::unique_ptr<sf::Texture> idleTexture;
 
         /**
          * Texture when the button has the mouse over it
          */
-        sf::Texture *activeTexture;
+        std::unique_ptr<sf::Texture> activeTexture;
 
         /**
          * Button sprite (the object that renders)
          */
-        sf::Sprite *sprite;
+        std::unique_ptr<sf::Sprite> sprite;
 
         /**
          * Button state (true and Idle = false)

--- a/src/entity/button.hpp
+++ b/src/entity/button.hpp
@@ -20,7 +20,7 @@ namespace entity {
          * @param idleTexture the texture of this button when the mouse is not hovering over it
          * @param activeTexture the texture of this button when the mouse is hovering over it
          */
-        Button(sf::Vector2f position, sf::Vector2f scale, sf::Texture& idleTexture, sf::Texture& activeTexture);
+        Button(sf::Vector2f position, sf::Vector2f scale, sf::Texture &idleTexture, sf::Texture &activeTexture);
 
         /**
          * Returns true if the button is active (i.e., the cursor is over the button)
@@ -46,17 +46,17 @@ namespace entity {
         /**
          * Texture when the button does not have the mouse over it
          */
-        sf::Texture* idleTexture;
+        sf::Texture *idleTexture;
 
         /**
          * Texture when the button has the mouse over it
          */
-        sf::Texture* activeTexture;
+        sf::Texture *activeTexture;
 
         /**
          * Button sprite (the object that renders)
          */
-        sf::Sprite* sprite;
+        sf::Sprite *sprite;
 
         /**
          * Button state (true and Idle = false)

--- a/src/entity/grid.cpp
+++ b/src/entity/grid.cpp
@@ -27,13 +27,14 @@ Grid::Grid(const map<shipNames, tuple<Coordinate, bool>> &shipPositions) {
         int x = get<0>(ship.second).getX();         // Topmost/leftmost x coordinate
         int y = get<0>(ship.second).getY();         // Topmost/leftmost y coordinate
         const bool horizontal = get<1>(ship.second);// If the ship is aligned horizontally
+        const int length = shipSize(shipName);      // Number of squares in this ship
 
         // Array of coordinates this ship occupies
-        Coordinate *&coordinates = get<0>(ships[shipName]);
-        coordinates = new Coordinate[shipSize(shipName)];
+        vector<Coordinate> &coordinates = get<0>(ships[shipName]);
+        coordinates = vector<Coordinate>(length);
 
         // Initializes the squares the ship occupies (from the top/left)
-        for (int i = 0; i < shipSize(shipName); ++i) {
+        for (int i = 0; i < length; ++i) {
             coordinates[i] = Coordinate(x, y);
             squares[y][x] = SHIP;
             horizontal ? x++ : y++;
@@ -63,9 +64,9 @@ SquareType Grid::attack(Coordinate &coord) {
         int &hitCount = get<1>(ships[shipName]);
 
         // Loop through the squares in this ship to see if it was hit
-        Coordinate *coords = get<0>(ship.second);
+        vector<Coordinate> coordinates = get<0>(ship.second);
         for (int i = 0; i < shipSize(shipName); ++i) {
-            if (coords[i] == coord) {// Found it!
+            if (coordinates[i] == coord) {// Found it!
                 hitCount++;
                 if (hitCount == shipSize(shipName)) {
                     shipStatuses[shipName] = true;// Ship has been sunk

--- a/src/entity/grid.cpp
+++ b/src/entity/grid.cpp
@@ -13,11 +13,10 @@ using std::get;
 
 Grid::Grid(const map<shipNames, tuple<Coordinate, bool>> &shipPositions) {
     // Initialize the grid itself with all water to start
-    squares = new SquareType *[size];
     for (int i = 0; i < size; ++i) {
-        squares[i] = new SquareType[size];
+        squares.emplace_back(vector<SquareType>());
         for (int j = 0; j < size; ++j) {
-            squares[i][j] = WATER;
+            squares[i].push_back(WATER);
         }
     }
 
@@ -88,44 +87,4 @@ map<shipNames, bool> &Grid::getShipStatus() {
 
 entity::Grid::Grid() {
     ;
-}
-
-
-// Big three
-Grid::~Grid() {
-    for (int i = 0; i < size; ++i) {
-        delete[] squares[i];
-    }
-    delete[] squares;
-}
-
-Grid::Grid(Grid &grid) {
-    // Copy the other ship's coordinates and number of hits
-    for (auto const &ship : grid.ships) {
-        *get<0>(ships[ship.first]) = *get<0>(ship.second);
-        get<1>(ships[ship.first]) = get<1>(ship.second);
-    }
-
-    // Copy the grid
-    for (int i = 0; i < size; ++i) {
-        for (int j = 0; j < size; ++j) {
-            this->squares[i][j] = grid.squares[i][j];
-        }
-    }
-}
-
-Grid &Grid::operator=(Grid *rhs) {
-    if (this == rhs) return *this;
-
-    this->ships.clear();
-    for (const auto ship : rhs->ships) {
-        this->ships.insert(ship);
-    }
-
-    for (int i = 0; i < size; ++i) {
-        for (int j = 0; j < size; ++j) {
-            squares[i][j] = rhs->squares[i][j];
-        }
-    }
-    return *this;
 }

--- a/src/entity/grid.hpp
+++ b/src/entity/grid.hpp
@@ -6,12 +6,12 @@
 #ifndef BATTLESHIP_GRID_H
 #define BATTLESHIP_GRID_H
 
-#include "coordinate.hpp"
 #include "../enums/shipNames.hpp"
 #include "../enums/squareType.hpp"
+#include "coordinate.hpp"
+#include <map>
 #include <memory>
 #include <vector>
-#include <map>
 
 using std::map;
 using std::tuple;

--- a/src/entity/grid.hpp
+++ b/src/entity/grid.hpp
@@ -66,7 +66,7 @@ namespace entity {
          *  -The coordinates it occupies on the board
          *  -The number of hits on this ship
          */
-        map<shipNames, tuple<Coordinate *, int>> ships;
+        map<shipNames, tuple<vector<Coordinate>, int>> ships;
 
         /**
          * Each ship with its top/left coordinate and whether it is horizontal or not

--- a/src/entity/grid.hpp
+++ b/src/entity/grid.hpp
@@ -23,7 +23,6 @@ namespace entity {
     class Grid {
     public:
         /**
-         * Constructs a grid
          * Constructs a grid with a list of ships
          *
          * @param ships the six ships on the grid with their orientations
@@ -60,11 +59,6 @@ namespace entity {
          */
         Grid();
 
-        // Big three
-        ~Grid();
-        Grid(Grid &other);
-        Grid &operator=(Grid *other);
-
     private:
         /**
          * The six ships on this board
@@ -89,7 +83,7 @@ namespace entity {
         /**
          * 10-by-10 array of grid squares
          */
-        SquareType **squares;
+        vector<vector<SquareType>> squares;
 
         /**
          * Size of the grid (both width and height) i.e 10

--- a/src/entity/target.cpp
+++ b/src/entity/target.cpp
@@ -7,10 +7,12 @@
 
 using entity::Target;
 
+// TODO: change to smart pointer
 sf::Texture Target::idleTexture = *new sf::Texture();
 sf::Texture Target::activeTexture = *new sf::Texture();
 
 void entity::Target::initializeTextures() {
+    // TODO: Take hte path as a param
     loadTexture(Target::idleTexture, "gameplay/idlePrimaryTarget.png");
     loadTexture(Target::activeTexture, "gameplay/ActivePrimaryTarget.png");
 }

--- a/src/entity/target.hpp
+++ b/src/entity/target.hpp
@@ -70,7 +70,6 @@ namespace entity {
          * Location of the target
          */
         Coordinate targetCoordinate;
-
     };
 
 }// namespace entity

--- a/src/enums/screens.hpp
+++ b/src/enums/screens.hpp
@@ -18,6 +18,6 @@ namespace screen {
         GAME_OVER
     };
 
-}// namespace screens
+}// namespace screen
 
 #endif// BATTLESHIP_SCREENS_H

--- a/src/helpers/ScreenResourceManager.cpp
+++ b/src/helpers/ScreenResourceManager.cpp
@@ -31,12 +31,12 @@ ScreenResourceManager::ScreenResourceManager(const vector<string> &texturePaths,
         auto sprite = &this->sprites[i];
         auto const position = get<0>(spritesData[i]);
         auto const scale = get<1>(spritesData[i]);
-        auto const texture = textures[get<2>(spritesData[i])];
+        auto const *texture = &textures[get<2>(spritesData[i])];
 
         // Initialize the sprite with its required data
         sprite->setPosition(position);
         sprite->setScale(scale);
-        sprite->setTexture(texture);
+        sprite->setTexture(*texture);
     }
 
     // Initialize the buttons

--- a/src/helpers/ScreenResourceManager.cpp
+++ b/src/helpers/ScreenResourceManager.cpp
@@ -41,17 +41,14 @@ ScreenResourceManager::ScreenResourceManager(const vector<string> &texturePaths,
 
     // Initialize the buttons
     for (const auto &button : buttons) {
-        this->buttons.emplace_back(get<0>(button), get<1>(button), textures[get<2>(button)], textures[get<3>(button)]);
-    }
-}
+        // Get the button data
+        auto const position = get<0>(button);
+        auto const scale = get<1>(button);
+        auto *idleTexture = &textures[get<2>(button)];
+        auto *activeTexture = &textures[get<3>(button)];
 
-sf::Texture &ScreenResourceManager::getTexture(const int index) {
-    if (index > textures.size()) {
-        std::ostringstream errMsg;
-        errMsg << "Error: must provide an index between 0 and " << textures.size() << "; " << index << " is invalid";
-        throw std::invalid_argument(errMsg.str());
+        this->buttons.emplace_back(position, scale, *idleTexture, *activeTexture);
     }
-    return textures[index];
 }
 
 sf::Sprite &ScreenResourceManager::getSprite(const int index) {

--- a/src/helpers/ScreenResourceManager.cpp
+++ b/src/helpers/ScreenResourceManager.cpp
@@ -51,19 +51,38 @@ ScreenResourceManager::ScreenResourceManager(const vector<string> &texturePaths,
     }
 }
 
+void ScreenResourceManager::addSprite(sf::Vector2f position, sf::Vector2f scale, int textureIndex) {
+    // Create a new sprite
+    this->sprites.emplace_back();
+    auto sprite = &this->sprites[sprites.size() - 1];
+    auto const *texture = &textures[textureIndex];
+
+    // Set the sprite attributes
+    sprite->setPosition(position);
+    sprite->setScale(scale);
+    sprite->setTexture(*texture);
+}
+
+void ScreenResourceManager::addButton(sf::Vector2f position, sf::Vector2f scale, int idleIndex, int activeIndex) {
+    auto *idleTexture = &textures[idleIndex];
+    auto *activeTexture = &textures[activeIndex];
+
+    this->buttons.emplace_back(position, scale, *idleTexture, *activeTexture);
+}
+
 sf::Sprite &ScreenResourceManager::getSprite(const int index) {
     if (index > sprites.size()) {
         std::ostringstream errMsg;
-        errMsg << "Error: must provide an index between 0 and " << sprites.size() << "; " << index << " is invalid";
+        errMsg << "Sprite Error: must provide an index between 0 and " << sprites.size() << "; " << index << " is invalid";
         throw std::invalid_argument(errMsg.str());
     }
     return sprites[index];
 }
 
 Button &ScreenResourceManager::getButton(const int index) {
-    if (index > sprites.size()) {
+    if (index > buttons.size()) {
         std::ostringstream errMsg;
-        errMsg << "Error: must provide an index between 0 and " << buttons.size() << "; " << index << " is invalid";
+        errMsg << "Button Error: must provide an index between 0 and " << buttons.size() << "; " << index << " is invalid";
         throw std::invalid_argument(errMsg.str());
     }
     return buttons[index];

--- a/src/helpers/ScreenResourceManager.cpp
+++ b/src/helpers/ScreenResourceManager.cpp
@@ -10,7 +10,7 @@ using std::get;
 ScreenResourceManager::ScreenResourceManager(const vector<string> &texturePaths,
                                              const vector<tuple<sf::Vector2f, sf::Vector2f, int>> &spritesData,
                                              const vector<tuple<sf::Vector2f, sf::Vector2f, int, int>> &buttons) {
-
+    // Initialize the textures
     for (int i = 0; i < texturePaths.size(); ++i) {
         // Add a new texture
         this->textures.emplace_back();
@@ -22,6 +22,7 @@ ScreenResourceManager::ScreenResourceManager(const vector<string> &texturePaths,
         }
     }
 
+    // Initialize the sprites
     for (int i = 0; i < spritesData.size(); ++i) {
         // Add a new sprite
         this->sprites.emplace_back();
@@ -36,6 +37,11 @@ ScreenResourceManager::ScreenResourceManager(const vector<string> &texturePaths,
         sprite->setPosition(position);
         sprite->setScale(scale);
         sprite->setTexture(texture);
+    }
+
+    // Initialize the buttons
+    for (const auto &button : buttons) {
+        this->buttons.emplace_back(get<0>(button), get<1>(button), textures[get<2>(button)], textures[get<3>(button)]);
     }
 }
 
@@ -63,7 +69,7 @@ Button &ScreenResourceManager::getButton(const int index) {
         errMsg << "Error: must provide an index between 0 and " << buttons.size() << "; " << index << " is invalid";
         throw std::invalid_argument(errMsg.str());
     }
-    return *buttons[index];
+    return buttons[index];
 }
 
 ScreenResourceManager::ScreenResourceManager() = default;

--- a/src/helpers/ScreenResourceManager.cpp
+++ b/src/helpers/ScreenResourceManager.cpp
@@ -7,7 +7,10 @@
 
 using std::get;
 
-ScreenResourceManager::ScreenResourceManager(const vector<string>& texturePaths, const vector<tuple<sf::Vector2f, sf::Vector2f, int>>& spritesData) {
+ScreenResourceManager::ScreenResourceManager(const vector<string> &texturePaths,
+                                             const vector<tuple<sf::Vector2f, sf::Vector2f, int>> &spritesData,
+                                             const vector<tuple<sf::Vector2f, sf::Vector2f, int, int>> &buttons) {
+
     for (int i = 0; i < texturePaths.size(); ++i) {
         // Add a new texture
         this->textures.emplace_back();
@@ -23,11 +26,16 @@ ScreenResourceManager::ScreenResourceManager(const vector<string>& texturePaths,
         // Add a new sprite
         this->sprites.emplace_back();
 
-        // Set the required data for the sprite
+        // Get the required data for the sprite
         auto sprite = &this->sprites[i];
-        sprite->setPosition(get<0>(spritesData[i]));
-        sprite->setScale(get<1>(spritesData[i]));
-        sprite->setTexture(textures[get<2>(spritesData[i])]);
+        auto const position = get<0>(spritesData[i]);
+        auto const scale = get<1>(spritesData[i]);
+        auto const texture = textures[get<2>(spritesData[i])];
+
+        // Initialize the sprite with its required data
+        sprite->setPosition(position);
+        sprite->setScale(scale);
+        sprite->setTexture(texture);
     }
 }
 
@@ -55,7 +63,7 @@ Button &ScreenResourceManager::getButton(const int index) {
         errMsg << "Error: must provide an index between 0 and " << buttons.size() << "; " << index << " is invalid";
         throw std::invalid_argument(errMsg.str());
     }
-    return buttons[index];
+    return *buttons[index];
 }
 
 ScreenResourceManager::ScreenResourceManager() = default;

--- a/src/helpers/ScreenResourceManager.cpp
+++ b/src/helpers/ScreenResourceManager.cpp
@@ -2,12 +2,12 @@
  *
  */
 
-#include "ImagesManager.hpp"
+#include "ScreenResourceManager.hpp"
 #include <sstream>
 
 using std::get;
 
-ImagesManager::ImagesManager(const vector<string>& texturePaths, const vector<tuple<sf::Vector2f, sf::Vector2f, int>>& spritesData) {
+ScreenResourceManager::ScreenResourceManager(const vector<string>& texturePaths, const vector<tuple<sf::Vector2f, sf::Vector2f, int>>& spritesData) {
     for (int i = 0; i < texturePaths.size(); ++i) {
         // Add a new texture
         this->textures.emplace_back();
@@ -31,7 +31,7 @@ ImagesManager::ImagesManager(const vector<string>& texturePaths, const vector<tu
     }
 }
 
-sf::Texture &ImagesManager::getTexture(const int index) {
+sf::Texture &ScreenResourceManager::getTexture(const int index) {
     if (index > textures.size()) {
         std::ostringstream errMsg;
         errMsg << "Error: must provide an index between 0 and " << textures.size() << "; " << index << " is invalid";
@@ -40,7 +40,7 @@ sf::Texture &ImagesManager::getTexture(const int index) {
     return textures[index];
 }
 
-sf::Sprite &ImagesManager::getSprite(const int index) {
+sf::Sprite &ScreenResourceManager::getSprite(const int index) {
     if (index > sprites.size()) {
         std::ostringstream errMsg;
         errMsg << "Error: must provide an index between 0 and " << sprites.size() << "; " << index << " is invalid";
@@ -49,4 +49,13 @@ sf::Sprite &ImagesManager::getSprite(const int index) {
     return sprites[index];
 }
 
-ImagesManager::ImagesManager() = default;
+Button &ScreenResourceManager::getButton(const int index) {
+    if (index > sprites.size()) {
+        std::ostringstream errMsg;
+        errMsg << "Error: must provide an index between 0 and " << buttons.size() << "; " << index << " is invalid";
+        throw std::invalid_argument(errMsg.str());
+    }
+    return buttons[index];
+}
+
+ScreenResourceManager::ScreenResourceManager() = default;

--- a/src/helpers/ScreenResourceManager.cpp
+++ b/src/helpers/ScreenResourceManager.cpp
@@ -18,6 +18,7 @@ ScreenResourceManager::ScreenResourceManager(const vector<string> &texturePaths,
         // Attempt to load the texture image
         auto texture = &this->textures[i];
         if (!texture->loadFromFile("../res/images/" + texturePaths[i])) {
+            std::cout << "Error: unable to open file: /res/images/" << texturePaths[i] << std::endl;
             exit(-1);
         }
     }

--- a/src/helpers/ScreenResourceManager.cpp
+++ b/src/helpers/ScreenResourceManager.cpp
@@ -18,7 +18,6 @@ ScreenResourceManager::ScreenResourceManager(const vector<string> &texturePaths,
         // Attempt to load the texture image
         auto texture = &this->textures[i];
         if (!texture->loadFromFile("../res/images/" + texturePaths[i])) {
-            std::cout << "Error: unable to open file: /res/images/" << texturePaths[i] << std::endl;
             exit(-1);
         }
     }

--- a/src/helpers/ScreenResourceManager.hpp
+++ b/src/helpers/ScreenResourceManager.hpp
@@ -8,6 +8,11 @@
 #include "../entity/button.hpp"
 #include "helperFunctions.hpp"
 
+// Required data to initialize a sprite: std::tuple<sf::Vector2f, sf::Vector2f, int>
+typedef std::tuple<sf::Vector2f, sf::Vector2f, int> sprite;
+// Required data to initialize a button: std::tuple<sf::Vector2f, sf::Vector2f, int, int>
+typedef std::tuple<sf::Vector2f, sf::Vector2f, int, int> button;
+
 using entity::Button;
 using std::tuple;
 using std::vector;
@@ -29,8 +34,8 @@ public:
      *                -The corresponding texture for when the button is active (its index in the texturePaths)
      */
     ScreenResourceManager(const vector<string> &texturePaths,
-                          const vector<tuple<sf::Vector2f, sf::Vector2f, int>> &sprites,
-                          const vector<tuple<sf::Vector2f, sf::Vector2f, int, int>> &buttons);
+                          const vector<sprite> &sprites,
+                          const vector<button> &buttons);
 
     void addSprite(sf::Vector2f, sf::Vector2f, int);
 

--- a/src/helpers/ScreenResourceManager.hpp
+++ b/src/helpers/ScreenResourceManager.hpp
@@ -5,12 +5,14 @@
 #ifndef BATTLESHIP_RESOURCEMANAGER_H
 #define BATTLESHIP_RESOURCEMANAGER_H
 
+#include "../entity/button.hpp"
 #include "helperFunctions.hpp"
 
-using std::vector;
 using std::tuple;
+using std::vector;
+using entity::Button;
 
-class ImagesManager {
+class ScreenResourceManager {
 public:
     /**
      * Initializes this manager with textures and sprites
@@ -21,12 +23,12 @@ public:
      *                -The scale of the sprite (sf::Vector2f)
      *                -The corresponding texture (its index in the texturePaths)
      */
-    ImagesManager(const vector<string>& texturePaths, const vector<tuple<sf::Vector2f, sf::Vector2f, int>>& sprites);
+    ScreenResourceManager(const vector<string> &texturePaths, const vector<tuple<sf::Vector2f, sf::Vector2f, int>> &sprites);
 
     /**
      * Default constructor
      */
-    ImagesManager();
+    ScreenResourceManager();
 
     /**
      * Returns a reference to the texture at the specified index
@@ -38,6 +40,11 @@ public:
      */
     sf::Sprite &getSprite(int index);
 
+    /**
+     * Returns a reference to the button at the specified index
+     */
+    Button &getButton(int index);
+
 private:
     /**
      * All the SFML textures in this manager
@@ -48,6 +55,12 @@ private:
      * All the SFML sprites in this manager
      */
     vector<sf::Sprite> sprites;
+
+    /**
+     * All the SFML buttons in this manager
+     */
+    vector<Button> buttons;
+
 };
 
 #endif//BATTLESHIP_RESOURCEMANAGER_H

--- a/src/helpers/ScreenResourceManager.hpp
+++ b/src/helpers/ScreenResourceManager.hpp
@@ -38,11 +38,6 @@ public:
     ScreenResourceManager();
 
     /**
-     * Returns a reference to the texture at the specified index
-     */
-    sf::Texture &getTexture(int index);
-
-    /**
      * Returns a reference to the sprite at the specified index
      */
     sf::Sprite &getSprite(int index);

--- a/src/helpers/ScreenResourceManager.hpp
+++ b/src/helpers/ScreenResourceManager.hpp
@@ -8,9 +8,9 @@
 #include "../entity/button.hpp"
 #include "helperFunctions.hpp"
 
+using entity::Button;
 using std::tuple;
 using std::vector;
-using entity::Button;
 
 class ScreenResourceManager {
 public:
@@ -22,8 +22,15 @@ public:
      *                -The initial position (sf::Vector2f)
      *                -The scale of the sprite (sf::Vector2f)
      *                -The corresponding texture (its index in the texturePaths)
+     * @param buttons data to initialize each button:
+     *                -The initial position (sf::Vector2f)
+     *                -The scale of the button (sf::Vector2f)
+     *                -The corresponding texture for when the button is idle (its index in the texturePaths)
+     *                -The corresponding texture for when the button is active (its index in the texturePaths)
      */
-    ScreenResourceManager(const vector<string> &texturePaths, const vector<tuple<sf::Vector2f, sf::Vector2f, int>> &sprites);
+    ScreenResourceManager(const vector<string> &texturePaths,
+                          const vector<tuple<sf::Vector2f, sf::Vector2f, int>> &sprites,
+                          const vector<tuple<sf::Vector2f, sf::Vector2f, int, int>> &buttons);
 
     /**
      * Default constructor
@@ -59,8 +66,7 @@ private:
     /**
      * All the SFML buttons in this manager
      */
-    vector<Button> buttons;
-
+    vector<unique_ptr<Button>> buttons;
 };
 
 #endif//BATTLESHIP_RESOURCEMANAGER_H

--- a/src/helpers/ScreenResourceManager.hpp
+++ b/src/helpers/ScreenResourceManager.hpp
@@ -66,7 +66,7 @@ private:
     /**
      * All the SFML buttons in this manager
      */
-    vector<unique_ptr<Button>> buttons;
+    vector<Button> buttons;
 };
 
 #endif//BATTLESHIP_RESOURCEMANAGER_H

--- a/src/helpers/ScreenResourceManager.hpp
+++ b/src/helpers/ScreenResourceManager.hpp
@@ -32,6 +32,10 @@ public:
                           const vector<tuple<sf::Vector2f, sf::Vector2f, int>> &sprites,
                           const vector<tuple<sf::Vector2f, sf::Vector2f, int, int>> &buttons);
 
+    void addSprite(sf::Vector2f, sf::Vector2f, int);
+
+    void addButton(sf::Vector2f, sf::Vector2f, int, int);
+
     /**
      * Default constructor
      */

--- a/src/screens/difficultySelection.cpp
+++ b/src/screens/difficultySelection.cpp
@@ -1,6 +1,5 @@
 /**
- * File: difficultySelection.cpp
- * Description: Front-end class that defines the behaviour of the Difficulty selection screens
+ * Front-end class that defines the behaviour of the Difficulty selection screens
  */
 
 #include "difficultySelection.hpp"
@@ -15,15 +14,15 @@ DifficultySelection::DifficultySelection() : ScreenTemplate() {
                                       "difficultySelection/IdleHardButton.png", "difficultySelection/ActiveHardButton.png",
                                       "difficultySelection/IdleBackButton.png", "difficultySelection/ActiveBackButton.png",
                                       "difficultySelection/IdleInstructionsButton.png", "difficultySelection/ActiveInstructionsButton.png"};
-    this->resources = ScreenResourceManager(texturePaths,
-                                            {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::Background_}},
-                                            {});
-    this->resources.addButton(sf::Vector2f(88 * 5, 92 * 5), sf::Vector2f(5, 5), textureNames::IdleEasyButton, textureNames::ActiveEasyButton);
-    this->resources.addButton(sf::Vector2f(200 * 5, 92 * 5), sf::Vector2f(5, 5), textureNames::IdleHardButton, textureNames::ActiveHardButton);
-    this->resources.addButton(sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleBackButton, textureNames::ActiveBackButton);
-    this->resources.addButton(sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleInstructionsButton, textureNames::ActiveInstructionsButton);
+    const vector<sprite> sprites = {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::Background_}};
+    const vector<button> buttons = {{sf::Vector2f(88 * 5, 92 * 5), sf::Vector2f(5, 5), textureNames::IdleEasyButton, textureNames::ActiveEasyButton},
+                                    //{sf::Vector2f(200 * 5, 92 * 5), sf::Vector2f(5, 5), textureNames::IdleHardButton, textureNames::ActiveHardButton},
+                                    //{sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleBackButton, textureNames::ActiveBackButton},
+                                    {sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleInstructionsButton, textureNames::ActiveInstructionsButton}};
+    this->resources = ScreenResourceManager(texturePaths, sprites, buttons);
 
-    loadTexture(this->difficultyBackgroundTexture, "difficultySelection/DifficultyBackground.png");
+
+    // TODO: Remove these manual textures and buttons
     loadTexture(this->idleEasyButtonTexture, "difficultySelection/IdleEasyButton.png");
     loadTexture(this->activeEasyButtonTexture, "difficultySelection/ActiveEasyButton.png");
     loadTexture(this->idleHardButtonTexture, "difficultySelection/IdleHardButton.png");
@@ -48,6 +47,7 @@ DifficultySelection &screen::DifficultySelection::getInstance() {
 
 void DifficultySelection::update() {
     sf::Vector2f mousePosition = State::getMousePosition();
+    resources.getButton(buttonNames::EasyButton).updateButtonState(mousePosition);
     this->easyButton->updateButtonState(mousePosition);
     this->hardButton->updateButtonState(mousePosition);
     this->backButton->updateButtonState(mousePosition);
@@ -65,7 +65,7 @@ void DifficultySelection::poll() {
                 break;
             case sf::Event::MouseButtonReleased:
                 if (event.mouseButton.button == sf::Mouse::Left) {
-                    if (this->easyButton->getButtonState()) {
+                    if (resources.getButton(EasyButton).getButtonState()) {
                         State::difficulty = State::Difficulty::EASY;
                         State::changeScreen(Screens::FLEET_PLACEMENT);
                         break;
@@ -94,7 +94,11 @@ void DifficultySelection::render() {
     gui.clear();
 
     gui.draw(resources.getSprite(spriteNames::Background));
-    easyButton->render(gui);
+    resources.getButton(EasyButton).render(gui);
+    // resources.getButton(buttonNames::HardButton).render(gui);
+    // resources.getButton(buttonNames::InstructionsButton).render(gui);
+    // resources.getButton(buttonNames::BackButton).render(gui);
+    //  easyButton->render(gui);
     hardButton->render(gui);
     backButton->render(gui);
     instructionsButton->render(gui);

--- a/src/screens/difficultySelection.cpp
+++ b/src/screens/difficultySelection.cpp
@@ -14,11 +14,11 @@ DifficultySelection::DifficultySelection() : ScreenTemplate() {
                                       "difficultySelection/IdleHardButton.png", "difficultySelection/ActiveHardButton.png",
                                       "difficultySelection/IdleBackButton.png", "difficultySelection/ActiveBackButton.png",
                                       "difficultySelection/IdleInstructionsButton.png", "difficultySelection/ActiveInstructionsButton.png"};
-    const vector<sprite> sprites = {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), Background_}};
-    const vector<button> buttons = {{sf::Vector2f(88 * 5, 92 * 5), sf::Vector2f(5, 5), IdleEasyButton, ActiveEasyButton},
+    const vector<sprite> sprites = {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::Background_}};
+    const vector<button> buttons = {{sf::Vector2f(88 * 5, 92 * 5), sf::Vector2f(5, 5), textureNames::IdleEasyButton, textureNames::ActiveEasyButton},
                                     //{sf::Vector2f(200 * 5, 92 * 5), sf::Vector2f(5, 5), textureNames::IdleHardButton, textureNames::ActiveHardButton},
                                     //{sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleBackButton, textureNames::ActiveBackButton},
-                                    {sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), IdleInstructionsButton, ActiveInstructionsButton}};
+                                    {sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleInstructionsButton, textureNames::ActiveInstructionsButton}};
     this->resources = ScreenResourceManager(texturePaths, sprites, buttons);
 
 
@@ -47,7 +47,7 @@ DifficultySelection &screen::DifficultySelection::getInstance() {
 
 void DifficultySelection::update() {
     sf::Vector2f mousePosition = State::getMousePosition();
-    resources.getButton(EasyButton).updateButtonState(mousePosition);
+    resources.getButton(buttonNames::EasyButton).updateButtonState(mousePosition);
     this->easyButton->updateButtonState(mousePosition);
     this->hardButton->updateButtonState(mousePosition);
     this->backButton->updateButtonState(mousePosition);
@@ -93,7 +93,7 @@ void DifficultySelection::render() {
     sf::RenderWindow &gui = *State::gui;
     gui.clear();
 
-    gui.draw(resources.getSprite(Background));
+    gui.draw(resources.getSprite(spriteNames::Background));
     resources.getButton(EasyButton).render(gui);
     // resources.getButton(buttonNames::HardButton).render(gui);
     // resources.getButton(buttonNames::InstructionsButton).render(gui);

--- a/src/screens/difficultySelection.cpp
+++ b/src/screens/difficultySelection.cpp
@@ -18,6 +18,10 @@ DifficultySelection::DifficultySelection() : ScreenTemplate() {
     this->resources = ScreenResourceManager(texturePaths,
                                             {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::Background_}},
                                             {});
+    this->resources.addButton(sf::Vector2f(88 * 5, 92 * 5), sf::Vector2f(5, 5), textureNames::IdleEasyButton, textureNames::ActiveEasyButton);
+    this->resources.addButton(sf::Vector2f(200 * 5, 92 * 5), sf::Vector2f(5, 5), textureNames::IdleHardButton, textureNames::ActiveHardButton);
+    this->resources.addButton(sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleBackButton, textureNames::ActiveBackButton);
+    this->resources.addButton(sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleInstructionsButton, textureNames::ActiveInstructionsButton);
 
     loadTexture(this->difficultyBackgroundTexture, "difficultySelection/DifficultyBackground.png");
     loadTexture(this->idleEasyButtonTexture, "difficultySelection/IdleEasyButton.png");

--- a/src/screens/difficultySelection.cpp
+++ b/src/screens/difficultySelection.cpp
@@ -10,6 +10,15 @@ using screen::DifficultySelection;
 std::unique_ptr<DifficultySelection> DifficultySelection::instance = nullptr;
 
 DifficultySelection::DifficultySelection() : ScreenTemplate() {
+    const vector<string> texturePaths{"difficultySelection/DifficultyBackground.png",
+                                      "difficultySelection/IdleEasyButton.png", "difficultySelection/ActiveEasyButton.png",
+                                      "difficultySelection/IdleHardButton.png", "difficultySelection/ActiveHardButton.png",
+                                      "difficultySelection/IdleBackButton.png", "difficultySelection/ActiveBackButton.png",
+                                      "difficultySelection/IdleInstructionsButton.png", "difficultySelection/ActiveInstructionsButton.png"};
+    this->resources = ScreenResourceManager(texturePaths,
+                                            {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::Background_}},
+                                            {});
+
     loadTexture(this->difficultyBackgroundTexture, "difficultySelection/DifficultyBackground.png");
     loadTexture(this->idleEasyButtonTexture, "difficultySelection/IdleEasyButton.png");
     loadTexture(this->activeEasyButtonTexture, "difficultySelection/ActiveEasyButton.png");

--- a/src/screens/difficultySelection.cpp
+++ b/src/screens/difficultySelection.cpp
@@ -14,11 +14,11 @@ DifficultySelection::DifficultySelection() : ScreenTemplate() {
                                       "difficultySelection/IdleHardButton.png", "difficultySelection/ActiveHardButton.png",
                                       "difficultySelection/IdleBackButton.png", "difficultySelection/ActiveBackButton.png",
                                       "difficultySelection/IdleInstructionsButton.png", "difficultySelection/ActiveInstructionsButton.png"};
-    const vector<sprite> sprites = {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::Background_}};
-    const vector<button> buttons = {{sf::Vector2f(88 * 5, 92 * 5), sf::Vector2f(5, 5), textureNames::IdleEasyButton, textureNames::ActiveEasyButton},
+    const vector<sprite> sprites = {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), Background_}};
+    const vector<button> buttons = {{sf::Vector2f(88 * 5, 92 * 5), sf::Vector2f(5, 5), IdleEasyButton, ActiveEasyButton},
                                     //{sf::Vector2f(200 * 5, 92 * 5), sf::Vector2f(5, 5), textureNames::IdleHardButton, textureNames::ActiveHardButton},
                                     //{sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleBackButton, textureNames::ActiveBackButton},
-                                    {sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleInstructionsButton, textureNames::ActiveInstructionsButton}};
+                                    {sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), IdleInstructionsButton, ActiveInstructionsButton}};
     this->resources = ScreenResourceManager(texturePaths, sprites, buttons);
 
 
@@ -47,7 +47,7 @@ DifficultySelection &screen::DifficultySelection::getInstance() {
 
 void DifficultySelection::update() {
     sf::Vector2f mousePosition = State::getMousePosition();
-    resources.getButton(buttonNames::EasyButton).updateButtonState(mousePosition);
+    resources.getButton(EasyButton).updateButtonState(mousePosition);
     this->easyButton->updateButtonState(mousePosition);
     this->hardButton->updateButtonState(mousePosition);
     this->backButton->updateButtonState(mousePosition);
@@ -93,7 +93,7 @@ void DifficultySelection::render() {
     sf::RenderWindow &gui = *State::gui;
     gui.clear();
 
-    gui.draw(resources.getSprite(spriteNames::Background));
+    gui.draw(resources.getSprite(Background));
     resources.getButton(EasyButton).render(gui);
     // resources.getButton(buttonNames::HardButton).render(gui);
     // resources.getButton(buttonNames::InstructionsButton).render(gui);

--- a/src/screens/difficultySelection.cpp
+++ b/src/screens/difficultySelection.cpp
@@ -7,7 +7,7 @@
 
 using screen::DifficultySelection;
 
-DifficultySelection *DifficultySelection::instance = nullptr;
+std::unique_ptr<DifficultySelection> DifficultySelection::instance = nullptr;
 
 DifficultySelection::DifficultySelection() : ScreenTemplate() {
     loadTexture(this->difficultyBackgroundTexture, "difficultySelection/DifficultyBackground.png");
@@ -22,15 +22,15 @@ DifficultySelection::DifficultySelection() : ScreenTemplate() {
 
     setSprite(sf::Vector2f(0, 0), sf::Vector2f(5, 5), this->difficultyBackgroundTexture, this->backgroundSprite);
 
-    this->easyButton = new Button(sf::Vector2f(88 * 5, 92 * 5), sf::Vector2f(5, 5), this->idleEasyButtonTexture, this->activeEasyButtonTexture);
-    this->hardButton = new Button(sf::Vector2f(200 * 5, 92 * 5), sf::Vector2f(5, 5), this->idleHardButtonTexture, this->activeHardButtonTexture);
-    this->backButton = new Button(sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), this->idleBackButtonTexture, this->activeBackButtonTexture);
+    this->easyButton = std::make_unique<Button>(sf::Vector2f(88 * 5, 92 * 5), sf::Vector2f(5, 5), this->idleEasyButtonTexture, this->activeEasyButtonTexture);
+    this->hardButton = std::make_unique<Button>(sf::Vector2f(200 * 5, 92 * 5), sf::Vector2f(5, 5), this->idleHardButtonTexture, this->activeHardButtonTexture);
+    this->backButton = std::make_unique<Button>(sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), this->idleBackButtonTexture, this->activeBackButtonTexture);
     this->instructionsButton = std::make_unique<Button>(sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), this->idleInstructionsButton, this->activeInstructionsButton);
 }
 
 DifficultySelection &screen::DifficultySelection::getInstance() {
     if (instance == nullptr) {
-        instance = new DifficultySelection();
+        instance.reset(new DifficultySelection());
     }
     return *instance;
 }

--- a/src/screens/difficultySelection.cpp
+++ b/src/screens/difficultySelection.cpp
@@ -1,5 +1,6 @@
 /**
- * Front-end class that defines the behaviour of the Difficulty selection screens
+ * File: difficultySelection.cpp
+ * Description: Front-end class that defines the behaviour of the Difficulty selection screens
  */
 
 #include "difficultySelection.hpp"
@@ -14,15 +15,15 @@ DifficultySelection::DifficultySelection() : ScreenTemplate() {
                                       "difficultySelection/IdleHardButton.png", "difficultySelection/ActiveHardButton.png",
                                       "difficultySelection/IdleBackButton.png", "difficultySelection/ActiveBackButton.png",
                                       "difficultySelection/IdleInstructionsButton.png", "difficultySelection/ActiveInstructionsButton.png"};
-    const vector<sprite> sprites = {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::Background_}};
-    const vector<button> buttons = {{sf::Vector2f(88 * 5, 92 * 5), sf::Vector2f(5, 5), textureNames::IdleEasyButton, textureNames::ActiveEasyButton},
-                                    //{sf::Vector2f(200 * 5, 92 * 5), sf::Vector2f(5, 5), textureNames::IdleHardButton, textureNames::ActiveHardButton},
-                                    //{sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleBackButton, textureNames::ActiveBackButton},
-                                    {sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleInstructionsButton, textureNames::ActiveInstructionsButton}};
-    this->resources = ScreenResourceManager(texturePaths, sprites, buttons);
+    this->resources = ScreenResourceManager(texturePaths,
+                                            {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::Background_}},
+                                            {});
+    this->resources.addButton(sf::Vector2f(88 * 5, 92 * 5), sf::Vector2f(5, 5), textureNames::IdleEasyButton, textureNames::ActiveEasyButton);
+    this->resources.addButton(sf::Vector2f(200 * 5, 92 * 5), sf::Vector2f(5, 5), textureNames::IdleHardButton, textureNames::ActiveHardButton);
+    this->resources.addButton(sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleBackButton, textureNames::ActiveBackButton);
+    this->resources.addButton(sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleInstructionsButton, textureNames::ActiveInstructionsButton);
 
-
-    // TODO: Remove these manual textures and buttons
+    loadTexture(this->difficultyBackgroundTexture, "difficultySelection/DifficultyBackground.png");
     loadTexture(this->idleEasyButtonTexture, "difficultySelection/IdleEasyButton.png");
     loadTexture(this->activeEasyButtonTexture, "difficultySelection/ActiveEasyButton.png");
     loadTexture(this->idleHardButtonTexture, "difficultySelection/IdleHardButton.png");
@@ -47,7 +48,6 @@ DifficultySelection &screen::DifficultySelection::getInstance() {
 
 void DifficultySelection::update() {
     sf::Vector2f mousePosition = State::getMousePosition();
-    resources.getButton(buttonNames::EasyButton).updateButtonState(mousePosition);
     this->easyButton->updateButtonState(mousePosition);
     this->hardButton->updateButtonState(mousePosition);
     this->backButton->updateButtonState(mousePosition);
@@ -65,7 +65,7 @@ void DifficultySelection::poll() {
                 break;
             case sf::Event::MouseButtonReleased:
                 if (event.mouseButton.button == sf::Mouse::Left) {
-                    if (resources.getButton(EasyButton).getButtonState()) {
+                    if (this->easyButton->getButtonState()) {
                         State::difficulty = State::Difficulty::EASY;
                         State::changeScreen(Screens::FLEET_PLACEMENT);
                         break;
@@ -94,11 +94,7 @@ void DifficultySelection::render() {
     gui.clear();
 
     gui.draw(resources.getSprite(spriteNames::Background));
-    resources.getButton(EasyButton).render(gui);
-    // resources.getButton(buttonNames::HardButton).render(gui);
-    // resources.getButton(buttonNames::InstructionsButton).render(gui);
-    // resources.getButton(buttonNames::BackButton).render(gui);
-    //  easyButton->render(gui);
+    easyButton->render(gui);
     hardButton->render(gui);
     backButton->render(gui);
     instructionsButton->render(gui);

--- a/src/screens/difficultySelection.cpp
+++ b/src/screens/difficultySelection.cpp
@@ -14,11 +14,11 @@ DifficultySelection::DifficultySelection() : ScreenTemplate() {
                                       "difficultySelection/IdleHardButton.png", "difficultySelection/ActiveHardButton.png",
                                       "difficultySelection/IdleBackButton.png", "difficultySelection/ActiveBackButton.png",
                                       "difficultySelection/IdleInstructionsButton.png", "difficultySelection/ActiveInstructionsButton.png"};
-    const vector<sprite> sprites = {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::Background_}};
-    const vector<button> buttons = {{sf::Vector2f(88 * 5, 92 * 5), sf::Vector2f(5, 5), textureNames::IdleEasyButton, textureNames::ActiveEasyButton},
-                                    {sf::Vector2f(200 * 5, 92 * 5), sf::Vector2f(5, 5), textureNames::IdleHardButton, textureNames::ActiveHardButton},
-                                    {sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleBackButton, textureNames::ActiveBackButton},
-                                    {sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleInstructionsButton, textureNames::ActiveInstructionsButton}};
+    const vector<sprite> sprites = {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), Background_}};
+    const vector<button> buttons = {{sf::Vector2f(88 * 5, 92 * 5), sf::Vector2f(5, 5), IdleEasyButton, ActiveEasyButton},
+                                    {sf::Vector2f(200 * 5, 92 * 5), sf::Vector2f(5, 5), IdleHardButton, ActiveHardButton},
+                                    {sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), IdleBackButton, ActiveBackButton},
+                                    {sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), IdleInstructionsButton, ActiveInstructionsButton}};
 
     this->resources = ScreenResourceManager(texturePaths, sprites, buttons);
 }
@@ -33,10 +33,10 @@ DifficultySelection &screen::DifficultySelection::getInstance() {
 void DifficultySelection::update() {
     sf::Vector2f mousePosition = State::getMousePosition();
 
-    resources.getButton(buttonNames::EasyButton).updateButtonState(mousePosition);
-    resources.getButton(buttonNames::HardButton).updateButtonState(mousePosition);
-    resources.getButton(buttonNames::BackButton).updateButtonState(mousePosition);
-    resources.getButton(buttonNames::InstructionsButton).updateButtonState(mousePosition);
+    resources.getButton(EasyButton).updateButtonState(mousePosition);
+    resources.getButton(HardButton).updateButtonState(mousePosition);
+    resources.getButton(BackButton).updateButtonState(mousePosition);
+    resources.getButton(InstructionsButton).updateButtonState(mousePosition);
 }
 
 void DifficultySelection::poll() {
@@ -50,18 +50,18 @@ void DifficultySelection::poll() {
                 break;
             case sf::Event::MouseButtonReleased:
                 if (event.mouseButton.button == sf::Mouse::Left) {
-                    if (resources.getButton(buttonNames::EasyButton).getButtonState()) {
+                    if (resources.getButton(EasyButton).getButtonState()) {
                         State::difficulty = State::Difficulty::EASY;
                         State::changeScreen(Screens::FLEET_PLACEMENT);
                         break;
-                    } else if (resources.getButton(buttonNames::HardButton).getButtonState()) {
+                    } else if (resources.getButton(HardButton).getButtonState()) {
                         State::difficulty = State::Difficulty::HARD;
                         State::changeScreen(Screens::FLEET_PLACEMENT);
                         break;
-                    } else if (resources.getButton(buttonNames::BackButton).getButtonState()) {
+                    } else if (resources.getButton(BackButton).getButtonState()) {
                         State::changeScreen(Screens::GAME_MODE_SELECTION);
                         break;
-                    } else if (resources.getButton(buttonNames::InstructionsButton).getButtonState()) {
+                    } else if (resources.getButton(InstructionsButton).getButtonState()) {
                         State::changeScreen(Screens::INSTRUCTIONS);
                         break;
                     } else {
@@ -78,11 +78,11 @@ void DifficultySelection::render() {
     sf::RenderWindow &gui = *State::gui;
     gui.clear();
 
-    gui.draw(resources.getSprite(spriteNames::Background));
-    resources.getButton(buttonNames::EasyButton).render(gui);
-    resources.getButton(buttonNames::HardButton).render(gui);
-    resources.getButton(buttonNames::BackButton).render(gui);
-    resources.getButton(buttonNames::InstructionsButton).render(gui);
+    gui.draw(resources.getSprite(Background));
+    resources.getButton(EasyButton).render(gui);
+    resources.getButton(HardButton).render(gui);
+    resources.getButton(BackButton).render(gui);
+    resources.getButton(InstructionsButton).render(gui);
 
     if (State::getCurrentScreen() == Screens::DIFFICULTY_SELECTION) {
         gui.display();

--- a/src/screens/difficultySelection.cpp
+++ b/src/screens/difficultySelection.cpp
@@ -17,14 +17,12 @@ DifficultySelection::DifficultySelection() : ScreenTemplate() {
                                       "difficultySelection/IdleInstructionsButton.png", "difficultySelection/ActiveInstructionsButton.png"};
     const vector<sprite> sprites = {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::Background_}};
     const vector<button> buttons = {{sf::Vector2f(88 * 5, 92 * 5), sf::Vector2f(5, 5), textureNames::IdleEasyButton, textureNames::ActiveEasyButton},
-                                    //{sf::Vector2f(200 * 5, 92 * 5), sf::Vector2f(5, 5), textureNames::IdleHardButton, textureNames::ActiveHardButton},
-                                    //{sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleBackButton, textureNames::ActiveBackButton},
+                                    {sf::Vector2f(200 * 5, 92 * 5), sf::Vector2f(5, 5), textureNames::IdleHardButton, textureNames::ActiveHardButton},
+                                    {sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleBackButton, textureNames::ActiveBackButton},
                                     {sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleInstructionsButton, textureNames::ActiveInstructionsButton}};
     this->resources = ScreenResourceManager(texturePaths, sprites, buttons);
 
     loadTexture(this->difficultyBackgroundTexture, "difficultySelection/DifficultyBackground.png");
-    loadTexture(this->idleEasyButtonTexture, "difficultySelection/IdleEasyButton.png");
-    loadTexture(this->activeEasyButtonTexture, "difficultySelection/ActiveEasyButton.png");
     loadTexture(this->idleHardButtonTexture, "difficultySelection/IdleHardButton.png");
     loadTexture(this->activeHardButtonTexture, "difficultySelection/ActiveHardButton.png");
     loadTexture(this->idleBackButtonTexture, "difficultySelection/IdleBackButton.png");
@@ -32,7 +30,6 @@ DifficultySelection::DifficultySelection() : ScreenTemplate() {
     loadTexture(this->idleInstructionsButton, "difficultySelection/IdleInstructionsButton.png");
     loadTexture(this->activeInstructionsButton, "difficultySelection/ActiveInstructionsButton.png");
 
-    this->easyButton = std::make_unique<Button>(sf::Vector2f(88 * 5, 92 * 5), sf::Vector2f(5, 5), this->idleEasyButtonTexture, this->activeEasyButtonTexture);
     this->hardButton = std::make_unique<Button>(sf::Vector2f(200 * 5, 92 * 5), sf::Vector2f(5, 5), this->idleHardButtonTexture, this->activeHardButtonTexture);
     this->backButton = std::make_unique<Button>(sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), this->idleBackButtonTexture, this->activeBackButtonTexture);
     this->instructionsButton = std::make_unique<Button>(sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), this->idleInstructionsButton, this->activeInstructionsButton);
@@ -47,8 +44,7 @@ DifficultySelection &screen::DifficultySelection::getInstance() {
 
 void DifficultySelection::update() {
     sf::Vector2f mousePosition = State::getMousePosition();
-    // resources.getButton(buttonNames::EasyButton).updateButtonState(mousePosition);
-    this->easyButton->updateButtonState(mousePosition);
+    resources.getButton(buttonNames::EasyButton).updateButtonState(mousePosition);
     this->hardButton->updateButtonState(mousePosition);
     this->backButton->updateButtonState(mousePosition);
     this->instructionsButton->updateButtonState(mousePosition);
@@ -65,7 +61,7 @@ void DifficultySelection::poll() {
                 break;
             case sf::Event::MouseButtonReleased:
                 if (event.mouseButton.button == sf::Mouse::Left) {
-                    if (this->easyButton->getButtonState()) {
+                    if (resources.getButton(buttonNames::EasyButton).getButtonState()) {
                         State::difficulty = State::Difficulty::EASY;
                         State::changeScreen(Screens::FLEET_PLACEMENT);
                         break;
@@ -94,7 +90,7 @@ void DifficultySelection::render() {
     gui.clear();
 
     gui.draw(resources.getSprite(spriteNames::Background));
-    easyButton->render(gui);
+    resources.getButton(buttonNames::EasyButton).render(gui);
     hardButton->render(gui);
     backButton->render(gui);
     instructionsButton->render(gui);

--- a/src/screens/difficultySelection.cpp
+++ b/src/screens/difficultySelection.cpp
@@ -29,8 +29,6 @@ DifficultySelection::DifficultySelection() : ScreenTemplate() {
     loadTexture(this->idleInstructionsButton, "difficultySelection/IdleInstructionsButton.png");
     loadTexture(this->activeInstructionsButton, "difficultySelection/ActiveInstructionsButton.png");
 
-    setSprite(sf::Vector2f(0, 0), sf::Vector2f(5, 5), this->difficultyBackgroundTexture, this->backgroundSprite);
-
     this->easyButton = std::make_unique<Button>(sf::Vector2f(88 * 5, 92 * 5), sf::Vector2f(5, 5), this->idleEasyButtonTexture, this->activeEasyButtonTexture);
     this->hardButton = std::make_unique<Button>(sf::Vector2f(200 * 5, 92 * 5), sf::Vector2f(5, 5), this->idleHardButtonTexture, this->activeHardButtonTexture);
     this->backButton = std::make_unique<Button>(sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), this->idleBackButtonTexture, this->activeBackButtonTexture);

--- a/src/screens/difficultySelection.cpp
+++ b/src/screens/difficultySelection.cpp
@@ -15,13 +15,12 @@ DifficultySelection::DifficultySelection() : ScreenTemplate() {
                                       "difficultySelection/IdleHardButton.png", "difficultySelection/ActiveHardButton.png",
                                       "difficultySelection/IdleBackButton.png", "difficultySelection/ActiveBackButton.png",
                                       "difficultySelection/IdleInstructionsButton.png", "difficultySelection/ActiveInstructionsButton.png"};
-    this->resources = ScreenResourceManager(texturePaths,
-                                            {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::Background_}},
-                                            {});
-    this->resources.addButton(sf::Vector2f(88 * 5, 92 * 5), sf::Vector2f(5, 5), textureNames::IdleEasyButton, textureNames::ActiveEasyButton);
-    this->resources.addButton(sf::Vector2f(200 * 5, 92 * 5), sf::Vector2f(5, 5), textureNames::IdleHardButton, textureNames::ActiveHardButton);
-    this->resources.addButton(sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleBackButton, textureNames::ActiveBackButton);
-    this->resources.addButton(sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleInstructionsButton, textureNames::ActiveInstructionsButton);
+    const vector<sprite> sprites = {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::Background_}};
+    const vector<button> buttons = {{sf::Vector2f(88 * 5, 92 * 5), sf::Vector2f(5, 5), textureNames::IdleEasyButton, textureNames::ActiveEasyButton},
+                                    //{sf::Vector2f(200 * 5, 92 * 5), sf::Vector2f(5, 5), textureNames::IdleHardButton, textureNames::ActiveHardButton},
+                                    //{sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleBackButton, textureNames::ActiveBackButton},
+                                    {sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleInstructionsButton, textureNames::ActiveInstructionsButton}};
+    this->resources = ScreenResourceManager(texturePaths, sprites, buttons);
 
     loadTexture(this->difficultyBackgroundTexture, "difficultySelection/DifficultyBackground.png");
     loadTexture(this->idleEasyButtonTexture, "difficultySelection/IdleEasyButton.png");
@@ -48,6 +47,7 @@ DifficultySelection &screen::DifficultySelection::getInstance() {
 
 void DifficultySelection::update() {
     sf::Vector2f mousePosition = State::getMousePosition();
+    // resources.getButton(buttonNames::EasyButton).updateButtonState(mousePosition);
     this->easyButton->updateButtonState(mousePosition);
     this->hardButton->updateButtonState(mousePosition);
     this->backButton->updateButtonState(mousePosition);

--- a/src/screens/difficultySelection.cpp
+++ b/src/screens/difficultySelection.cpp
@@ -58,30 +58,29 @@ void DifficultySelection::poll() {
 
     while (gui.pollEvent(event)) {
         switch (event.type) {
-
             case sf::Event::Closed:
                 gui.close();
                 break;
-
             case sf::Event::MouseButtonReleased:
-                if ((event.mouseButton.button == sf::Mouse::Left) && (this->easyButton->getButtonState())) {
-                    State::difficulty = State::Difficulty::EASY;
-                    State::changeScreen(Screens::FLEET_PLACEMENT);
-                    break;
-                } else if ((event.mouseButton.button == sf::Mouse::Left) && (this->hardButton->getButtonState())) {
-                    State::difficulty = State::Difficulty::HARD;
-                    State::changeScreen(Screens::FLEET_PLACEMENT);
-                    break;
-                } else if ((event.mouseButton.button == sf::Mouse::Left) && (this->backButton->getButtonState())) {
-                    State::changeScreen(Screens::GAME_MODE_SELECTION);
-                    break;
-                } else if ((event.mouseButton.button == sf::Mouse::Left) && (this->instructionsButton->getButtonState())) {
-                    State::changeScreen(Screens::INSTRUCTIONS);
-                    break;
-                } else {
-                    break;
+                if (event.mouseButton.button == sf::Mouse::Left) {
+                    if (this->easyButton->getButtonState()) {
+                        State::difficulty = State::Difficulty::EASY;
+                        State::changeScreen(Screens::FLEET_PLACEMENT);
+                        break;
+                    } else if (this->hardButton->getButtonState()) {
+                        State::difficulty = State::Difficulty::HARD;
+                        State::changeScreen(Screens::FLEET_PLACEMENT);
+                        break;
+                    } else if (this->backButton->getButtonState()) {
+                        State::changeScreen(Screens::GAME_MODE_SELECTION);
+                        break;
+                    } else if (this->instructionsButton->getButtonState()) {
+                        State::changeScreen(Screens::INSTRUCTIONS);
+                        break;
+                    } else {
+                        break;
+                    }
                 }
-
             default:
                 break;
         }
@@ -92,7 +91,7 @@ void DifficultySelection::render() {
     sf::RenderWindow &gui = *State::gui;
     gui.clear();
 
-    gui.draw(this->backgroundSprite);
+    gui.draw(resources.getSprite(spriteNames::Background));
     easyButton->render(gui);
     hardButton->render(gui);
     backButton->render(gui);

--- a/src/screens/difficultySelection.cpp
+++ b/src/screens/difficultySelection.cpp
@@ -4,7 +4,6 @@
  */
 
 #include "difficultySelection.hpp"
-#include "../helpers/helperFunctions.hpp"
 
 using screen::DifficultySelection;
 
@@ -93,10 +92,4 @@ void DifficultySelection::render() {
     if (State::getCurrentScreen() == Screens::DIFFICULTY_SELECTION) {
         gui.display();
     }
-}
-
-void DifficultySelection::run() {
-    this->update();
-    this->poll();
-    this->render();
 }

--- a/src/screens/difficultySelection.cpp
+++ b/src/screens/difficultySelection.cpp
@@ -1,6 +1,5 @@
 /**
- * File: difficultySelection.cpp
- * Description: Front-end class that defines the behaviour of the Difficulty selection screens
+ * Front-end class that defines the behaviour of the Difficulty selection screens
  */
 
 #include "difficultySelection.hpp"
@@ -20,19 +19,8 @@ DifficultySelection::DifficultySelection() : ScreenTemplate() {
                                     {sf::Vector2f(200 * 5, 92 * 5), sf::Vector2f(5, 5), textureNames::IdleHardButton, textureNames::ActiveHardButton},
                                     {sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleBackButton, textureNames::ActiveBackButton},
                                     {sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleInstructionsButton, textureNames::ActiveInstructionsButton}};
+
     this->resources = ScreenResourceManager(texturePaths, sprites, buttons);
-
-    loadTexture(this->difficultyBackgroundTexture, "difficultySelection/DifficultyBackground.png");
-    loadTexture(this->idleHardButtonTexture, "difficultySelection/IdleHardButton.png");
-    loadTexture(this->activeHardButtonTexture, "difficultySelection/ActiveHardButton.png");
-    loadTexture(this->idleBackButtonTexture, "difficultySelection/IdleBackButton.png");
-    loadTexture(this->activeBackButtonTexture, "difficultySelection/ActiveBackButton.png");
-    loadTexture(this->idleInstructionsButton, "difficultySelection/IdleInstructionsButton.png");
-    loadTexture(this->activeInstructionsButton, "difficultySelection/ActiveInstructionsButton.png");
-
-    this->hardButton = std::make_unique<Button>(sf::Vector2f(200 * 5, 92 * 5), sf::Vector2f(5, 5), this->idleHardButtonTexture, this->activeHardButtonTexture);
-    this->backButton = std::make_unique<Button>(sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), this->idleBackButtonTexture, this->activeBackButtonTexture);
-    this->instructionsButton = std::make_unique<Button>(sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), this->idleInstructionsButton, this->activeInstructionsButton);
 }
 
 DifficultySelection &screen::DifficultySelection::getInstance() {
@@ -44,10 +32,11 @@ DifficultySelection &screen::DifficultySelection::getInstance() {
 
 void DifficultySelection::update() {
     sf::Vector2f mousePosition = State::getMousePosition();
+
     resources.getButton(buttonNames::EasyButton).updateButtonState(mousePosition);
-    this->hardButton->updateButtonState(mousePosition);
-    this->backButton->updateButtonState(mousePosition);
-    this->instructionsButton->updateButtonState(mousePosition);
+    resources.getButton(buttonNames::HardButton).updateButtonState(mousePosition);
+    resources.getButton(buttonNames::BackButton).updateButtonState(mousePosition);
+    resources.getButton(buttonNames::InstructionsButton).updateButtonState(mousePosition);
 }
 
 void DifficultySelection::poll() {
@@ -65,14 +54,14 @@ void DifficultySelection::poll() {
                         State::difficulty = State::Difficulty::EASY;
                         State::changeScreen(Screens::FLEET_PLACEMENT);
                         break;
-                    } else if (this->hardButton->getButtonState()) {
+                    } else if (resources.getButton(buttonNames::HardButton).getButtonState()) {
                         State::difficulty = State::Difficulty::HARD;
                         State::changeScreen(Screens::FLEET_PLACEMENT);
                         break;
-                    } else if (this->backButton->getButtonState()) {
+                    } else if (resources.getButton(buttonNames::BackButton).getButtonState()) {
                         State::changeScreen(Screens::GAME_MODE_SELECTION);
                         break;
-                    } else if (this->instructionsButton->getButtonState()) {
+                    } else if (resources.getButton(buttonNames::InstructionsButton).getButtonState()) {
                         State::changeScreen(Screens::INSTRUCTIONS);
                         break;
                     } else {
@@ -91,9 +80,9 @@ void DifficultySelection::render() {
 
     gui.draw(resources.getSprite(spriteNames::Background));
     resources.getButton(buttonNames::EasyButton).render(gui);
-    hardButton->render(gui);
-    backButton->render(gui);
-    instructionsButton->render(gui);
+    resources.getButton(buttonNames::HardButton).render(gui);
+    resources.getButton(buttonNames::BackButton).render(gui);
+    resources.getButton(buttonNames::InstructionsButton).render(gui);
 
     if (State::getCurrentScreen() == Screens::DIFFICULTY_SELECTION) {
         gui.display();

--- a/src/screens/difficultySelection.cpp
+++ b/src/screens/difficultySelection.cpp
@@ -8,7 +8,7 @@
 
 using screen::DifficultySelection;
 
-DifficultySelection* DifficultySelection::instance = nullptr;
+DifficultySelection *DifficultySelection::instance = nullptr;
 
 DifficultySelection::DifficultySelection() : ScreenTemplate() {
     loadTexture(this->difficultyBackgroundTexture, "difficultySelection/DifficultyBackground.png");
@@ -26,7 +26,7 @@ DifficultySelection::DifficultySelection() : ScreenTemplate() {
     this->easyButton = new Button(sf::Vector2f(88 * 5, 92 * 5), sf::Vector2f(5, 5), this->idleEasyButtonTexture, this->activeEasyButtonTexture);
     this->hardButton = new Button(sf::Vector2f(200 * 5, 92 * 5), sf::Vector2f(5, 5), this->idleHardButtonTexture, this->activeHardButtonTexture);
     this->backButton = new Button(sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), this->idleBackButtonTexture, this->activeBackButtonTexture);
-    this->instructionsButton = new Button(sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), this->idleInstructionsButton, this->activeInstructionsButton);
+    this->instructionsButton = std::make_unique<Button>(sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), this->idleInstructionsButton, this->activeInstructionsButton);
 }
 
 DifficultySelection &screen::DifficultySelection::getInstance() {

--- a/src/screens/difficultySelection.hpp
+++ b/src/screens/difficultySelection.hpp
@@ -30,11 +30,6 @@ namespace screen {
          */
         DifficultySelection &operator=(const DifficultySelection &source) = delete;
 
-        /**
-         * Overridden run method of screenTemplate
-         */
-        void run() override;
-
     private:
         /**
          *

--- a/src/screens/difficultySelection.hpp
+++ b/src/screens/difficultySelection.hpp
@@ -1,6 +1,5 @@
 /**
- * File: difficultySelection.h
- * Description: Front-end class that defines the behaviour of the Difficulty selection screens
+ * Front-end class that defines the behaviour of the Difficulty selection screens
  */
 
 #ifndef BATTLESHIP_DIFFICULTYSELECTION_H
@@ -63,23 +62,6 @@ namespace screen {
             BackButton,
             InstructionsButton
         };
-
-        sf::Texture difficultyBackgroundTexture;
-        sf::Texture idleEasyButtonTexture;
-        sf::Texture activeEasyButtonTexture;
-        sf::Texture idleHardButtonTexture;
-        sf::Texture activeHardButtonTexture;
-        sf::Texture idleBackButtonTexture;
-        sf::Texture activeBackButtonTexture;
-        sf::Texture idleInstructionsButton;
-        sf::Texture activeInstructionsButton;
-
-        sf::Sprite backgroundSprite;
-
-        std::unique_ptr<Button> easyButton;
-        std::unique_ptr<Button> hardButton;
-        std::unique_ptr<Button> backButton;
-        std::unique_ptr<Button> instructionsButton;
     };
 }// namespace screen
 

--- a/src/screens/difficultySelection.hpp
+++ b/src/screens/difficultySelection.hpp
@@ -64,6 +64,7 @@ namespace screen {
             InstructionsButton
         };
 
+        sf::Texture difficultyBackgroundTexture;
         sf::Texture idleEasyButtonTexture;
         sf::Texture activeEasyButtonTexture;
         sf::Texture idleHardButtonTexture;
@@ -72,6 +73,8 @@ namespace screen {
         sf::Texture activeBackButtonTexture;
         sf::Texture idleInstructionsButton;
         sf::Texture activeInstructionsButton;
+
+        sf::Sprite backgroundSprite;
 
         std::unique_ptr<Button> easyButton;
         std::unique_ptr<Button> hardButton;

--- a/src/screens/difficultySelection.hpp
+++ b/src/screens/difficultySelection.hpp
@@ -114,7 +114,7 @@ namespace screen {
         /**
          * Instructions button
          */
-        Button *instructionsButton;
+        std::unique_ptr<Button> instructionsButton;
 
         /**
          * Calls helpers::updateMousePosition() and entity::Button::updateButtonState()

--- a/src/screens/difficultySelection.hpp
+++ b/src/screens/difficultySelection.hpp
@@ -6,8 +6,8 @@
 #ifndef BATTLESHIP_DIFFICULTYSELECTION_H
 #define BATTLESHIP_DIFFICULTYSELECTION_H
 
-#include "../entity/button.hpp"
 #include "../controllers/screenTemplate.hpp"
+#include "../entity/button.hpp"
 #include <SFML/System.hpp>
 
 using entity::Button;
@@ -18,7 +18,7 @@ namespace screen {
         /**
          *
          */
-        static DifficultySelection& getInstance();
+        static DifficultySelection &getInstance();
 
         /**
          * Copy constructor
@@ -32,14 +32,36 @@ namespace screen {
 
     private:
         /**
-         *
+         * Singleton instance
          */
-        static DifficultySelection *instance;
+        static std::unique_ptr<DifficultySelection> instance;
 
         /**
-         *
+         * Singleton constructor
          */
         DifficultySelection();
+
+        // SFML event loop helpers
+        void update() override;
+        void poll() override;
+        void render() override;
+
+        /**
+         * Names to refer to the textures on this screen
+         */
+        enum textureNames { Background,
+                            IdlePlayButton,
+                            ActivePlayButton };
+
+        /**
+         * Names to refer to the sprites on this screen
+         */
+        enum spriteNames { Backgrounds };
+
+        /**
+         * Play button
+         */
+        std::unique_ptr<Button> playButton;
 
         /**
          * Background texture
@@ -94,39 +116,23 @@ namespace screen {
         /**
          * Easy button
          */
-        Button *easyButton;
+        std::unique_ptr<Button> easyButton;
 
         /**
          * Hard button
          */
-        Button *hardButton;
+        std::unique_ptr<Button> hardButton;
 
         /**
          * Back button
          */
-        Button *backButton;
+        std::unique_ptr<Button> backButton;
 
         /**
          * Instructions button
          */
         std::unique_ptr<Button> instructionsButton;
-
-        /**
-         * Calls helpers::updateMousePosition() and entity::Button::updateButtonState()
-         */
-        void update();
-
-        /**
-         * Polls for system events
-         */
-        void poll();
-
-        /**
-         * Renders all sprites
-         */
-        void render();
-
     };
-}// namespace screens
+}// namespace screen
 
 #endif// BATTLESHIP_DIFFICULTYSELECTION_H

--- a/src/screens/difficultySelection.hpp
+++ b/src/screens/difficultySelection.hpp
@@ -31,14 +31,10 @@ namespace screen {
         DifficultySelection &operator=(const DifficultySelection &source) = delete;
 
     private:
-        /**
-         * Singleton instance
-         */
+        // Singleton instance
         static std::unique_ptr<DifficultySelection> instance;
 
-        /**
-         * Singleton constructor
-         */
+        // Singleton constructor
         DifficultySelection();
 
         // SFML event loop helpers
@@ -46,91 +42,43 @@ namespace screen {
         void poll() override;
         void render() override;
 
-        /**
-         * Names to refer to the textures on this screen
-         */
-        enum textureNames { Background,
-                            IdlePlayButton,
-                            ActivePlayButton };
+        // Names to refer to resources on this screen
+        enum textureNames {
+            Background_,
+            IdleEasyButton,
+            ActiveEasyButton,
+            IdleHardButton,
+            ActiveHardButton,
+            IdleBackButton,
+            ActiveBackButton,
+            IdleInstructionsButton,
+            ActiveInstructionsButton
+        };
+        enum spriteNames {
+            Background
+        };
+        enum buttonNames {
+            EasyButton,
+            HardButton,
+            BackButton,
+            InstructionsButton
+        };
 
-        /**
-         * Names to refer to the sprites on this screen
-         */
-        enum spriteNames { Backgrounds };
-
-        /**
-         * Play button
-         */
-        std::unique_ptr<Button> playButton;
-
-        /**
-         * Background texture
-         */
         sf::Texture difficultyBackgroundTexture;
-
-        /**
-         * Idle easy button texture
-         */
         sf::Texture idleEasyButtonTexture;
-
-        /**
-         * Active easy button texture
-         */
         sf::Texture activeEasyButtonTexture;
-
-        /**
-         * Idle hard button texture
-         */
         sf::Texture idleHardButtonTexture;
-
-        /**
-         * Active hard button texture
-         */
         sf::Texture activeHardButtonTexture;
-
-        /**
-         * Idle back button texture
-         */
         sf::Texture idleBackButtonTexture;
-
-        /**
-         * Active back button texture
-         */
         sf::Texture activeBackButtonTexture;
-
-        /**
-         * Idle instructions button texture
-         */
         sf::Texture idleInstructionsButton;
-
-        /**
-         * Active instructions button texture
-         */
         sf::Texture activeInstructionsButton;
 
-        /**
-         * Background sprite
-         */
         sf::Sprite backgroundSprite;
 
-        /**
-         * Easy button
-         */
         std::unique_ptr<Button> easyButton;
-
-        /**
-         * Hard button
-         */
         std::unique_ptr<Button> hardButton;
-
-        /**
-         * Back button
-         */
         std::unique_ptr<Button> backButton;
-
-        /**
-         * Instructions button
-         */
         std::unique_ptr<Button> instructionsButton;
     };
 }// namespace screen

--- a/src/screens/difficultySelection.hpp
+++ b/src/screens/difficultySelection.hpp
@@ -64,7 +64,6 @@ namespace screen {
             InstructionsButton
         };
 
-        sf::Texture difficultyBackgroundTexture;
         sf::Texture idleEasyButtonTexture;
         sf::Texture activeEasyButtonTexture;
         sf::Texture idleHardButtonTexture;
@@ -73,8 +72,6 @@ namespace screen {
         sf::Texture activeBackButtonTexture;
         sf::Texture idleInstructionsButton;
         sf::Texture activeInstructionsButton;
-
-        sf::Sprite backgroundSprite;
 
         std::unique_ptr<Button> easyButton;
         std::unique_ptr<Button> hardButton;

--- a/src/screens/fleetPlacement.cpp
+++ b/src/screens/fleetPlacement.cpp
@@ -124,72 +124,72 @@ void FleetPlacement::randomize() {
 }
 
 void FleetPlacement::updateFleetLayout() {
-    sf::Sprite *battleship = &resources.getSprite(Battleship);
-    sf::Sprite *aircraftCarrier = &resources.getSprite(AircraftCarrier);
-    sf::Sprite *destroyer = &resources.getSprite(Destroyer);
-    sf::Sprite *submarine = &resources.getSprite(Submarine);
-    sf::Sprite *patrolBoat = &resources.getSprite(PatrolBoat);
-    sf::Sprite *rowBoat = &resources.getSprite(RowBoat);
+    sf::Sprite &battleship = resources.getSprite(Battleship);
+    sf::Sprite &aircraftCarrier = resources.getSprite(AircraftCarrier);
+    sf::Sprite &destroyer = resources.getSprite(Destroyer);
+    sf::Sprite &submarine = resources.getSprite(Submarine);
+    sf::Sprite &patrolBoat = resources.getSprite(PatrolBoat);
+    sf::Sprite &rowBoat = resources.getSprite(RowBoat);
 
     if (get<1>(this->ships[shipNames::BATTLESHIP]) == 1) {
-        battleship->setPosition(sf::Vector2f((224 + (get<0>(this->ships[shipNames::BATTLESHIP]).getX() * 16)) * 5,
+        battleship.setPosition(sf::Vector2f((224 + (get<0>(this->ships[shipNames::BATTLESHIP]).getX() * 16)) * 5,
                                             (28 + (get<0>(this->ships[shipNames::BATTLESHIP]).getY() * 16)) * 5));
-        battleship->setRotation(90.f);
+        battleship.setRotation(90.f);
     } else {
-        battleship->setPosition(sf::Vector2f((128 + (get<0>(this->ships[shipNames::BATTLESHIP]).getX() * 16)) * 5,
+        battleship.setPosition(sf::Vector2f((128 + (get<0>(this->ships[shipNames::BATTLESHIP]).getX() * 16)) * 5,
                                             (28 + (get<0>(this->ships[shipNames::BATTLESHIP]).getY() * 16)) * 5));
-        battleship->setRotation(0);
+        battleship.setRotation(0);
     }
 
     if (get<1>(this->ships[shipNames::AIRCRAFT_CARRIER]) == 1) {
-        aircraftCarrier->setPosition(sf::Vector2f((208 + (get<0>(this->ships[shipNames::AIRCRAFT_CARRIER]).getX() * 16)) * 5,
+        aircraftCarrier.setPosition(sf::Vector2f((208 + (get<0>(this->ships[shipNames::AIRCRAFT_CARRIER]).getX() * 16)) * 5,
                                                  (28 + (get<0>(this->ships[shipNames::AIRCRAFT_CARRIER]).getY() * 16)) * 5));
-        aircraftCarrier->setRotation(90.f);
+        aircraftCarrier.setRotation(90.f);
     } else {
-        aircraftCarrier->setPosition(sf::Vector2f((128 + (get<0>(this->ships[shipNames::AIRCRAFT_CARRIER]).getX() * 16)) * 5,
+        aircraftCarrier.setPosition(sf::Vector2f((128 + (get<0>(this->ships[shipNames::AIRCRAFT_CARRIER]).getX() * 16)) * 5,
                                                  (28 + (get<0>(this->ships[shipNames::AIRCRAFT_CARRIER]).getY() * 16)) * 5));
-        aircraftCarrier->setRotation(0);
+        aircraftCarrier.setRotation(0);
     }
 
     if (get<1>(this->ships[shipNames::DESTROYER]) == 1) {
         destroyer
-                ->setPosition(sf::Vector2f((192 + (get<0>(this->ships[shipNames::DESTROYER]).getX() * 16)) * 5,
+                .setPosition(sf::Vector2f((192 + (get<0>(this->ships[shipNames::DESTROYER]).getX() * 16)) * 5,
                                           (28 + (get<0>(this->ships[shipNames::DESTROYER]).getY() * 16)) * 5));
-        destroyer->setRotation(90.f);
+        destroyer.setRotation(90.f);
     } else {
-        destroyer->setPosition(sf::Vector2f((128 + (get<0>(this->ships[shipNames::DESTROYER]).getX() * 16)) * 5,
+        destroyer.setPosition(sf::Vector2f((128 + (get<0>(this->ships[shipNames::DESTROYER]).getX() * 16)) * 5,
                                            (28 + (get<0>(this->ships[shipNames::DESTROYER]).getY() * 16)) * 5));
-        destroyer->setRotation(0);
+        destroyer.setRotation(0);
     }
 
     if (get<1>(this->ships[shipNames::SUBMARINE]) == 1) {
-        submarine->setPosition(sf::Vector2f((176 + (get<0>(this->ships[shipNames::SUBMARINE]).getX() * 16)) * 5,
+        submarine.setPosition(sf::Vector2f((176 + (get<0>(this->ships[shipNames::SUBMARINE]).getX() * 16)) * 5,
                                            (28 + (get<0>(this->ships[shipNames::SUBMARINE]).getY() * 16)) * 5));
-        submarine->setRotation(90.f);
+        submarine.setRotation(90.f);
     } else {
-        submarine->setPosition(sf::Vector2f((128 + (get<0>(this->ships[shipNames::SUBMARINE]).getX() * 16)) * 5,
+        submarine.setPosition(sf::Vector2f((128 + (get<0>(this->ships[shipNames::SUBMARINE]).getX() * 16)) * 5,
                                            (28 + (get<0>(this->ships[shipNames::SUBMARINE]).getY() * 16)) * 5));
-        submarine->setRotation(0);
+        submarine.setRotation(0);
     }
 
     if (get<1>(this->ships[shipNames::PATROL_BOAT]) == 1) {
-        patrolBoat->setPosition(sf::Vector2f((160 + (get<0>(this->ships[shipNames::PATROL_BOAT]).getX() * 16)) * 5,
+        patrolBoat.setPosition(sf::Vector2f((160 + (get<0>(this->ships[shipNames::PATROL_BOAT]).getX() * 16)) * 5,
                                             (28 + (get<0>(this->ships[shipNames::PATROL_BOAT]).getY() * 16)) * 5));
-        patrolBoat->setRotation(90.f);
+        patrolBoat.setRotation(90.f);
     } else {
-        patrolBoat->setPosition(sf::Vector2f((128 + (get<0>(this->ships[shipNames::PATROL_BOAT]).getX() * 16)) * 5,
+        patrolBoat.setPosition(sf::Vector2f((128 + (get<0>(this->ships[shipNames::PATROL_BOAT]).getX() * 16)) * 5,
                                             (28 + (get<0>(this->ships[shipNames::PATROL_BOAT]).getY() * 16)) * 5));
-        patrolBoat->setRotation(0);
+        patrolBoat.setRotation(0);
     }
 
     if (get<1>(this->ships[shipNames::ROW_BOAT]) == 1) {
-        rowBoat->setPosition(sf::Vector2f((144 + (get<0>(this->ships[shipNames::ROW_BOAT]).getX() * 16)) * 5,
+        rowBoat.setPosition(sf::Vector2f((144 + (get<0>(this->ships[shipNames::ROW_BOAT]).getX() * 16)) * 5,
                                          (28 + (get<0>(this->ships[shipNames::ROW_BOAT]).getY() * 16)) * 5));
-        rowBoat->setRotation(90.0);
+        rowBoat.setRotation(90.0);
     } else {
-        rowBoat->setPosition(sf::Vector2f((128 + (get<0>(this->ships[shipNames::ROW_BOAT]).getX() * 16)) * 5,
+        rowBoat.setPosition(sf::Vector2f((128 + (get<0>(this->ships[shipNames::ROW_BOAT]).getX() * 16)) * 5,
                                          (28 + (get<0>(this->ships[shipNames::ROW_BOAT]).getY() * 16)) * 5));
-        rowBoat->setRotation(0);
+        rowBoat.setRotation(0);
     }
 }
 

--- a/src/screens/fleetPlacement.cpp
+++ b/src/screens/fleetPlacement.cpp
@@ -22,54 +22,53 @@ FleetPlacement::FleetPlacement() : ScreenTemplate() {
     const vector<sprite> sprites = {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), BackgroundDefault_},
                                     {sf::Vector2f(0, 0), sf::Vector2f(5, 5), BackgroundP1_},
                                     {sf::Vector2f(0, 0), sf::Vector2f(5, 5), BackgroundP2_},
-                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), Battleship_},
-                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), AircraftCarrier_},
-                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), Destroyer_},
-                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), Submarine_},
-                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), PatrolBoat_},
-                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), RowBoat_}};
-    const vector<button> buttons = {{sf::Vector2f(88 * 5, 92 * 5), sf::Vector2f(5, 5), IdleReadyButton, ActiveReadyButton},
-                                    {sf::Vector2f(200 * 5, 92 * 5), sf::Vector2f(5, 5), IdleRandomizeButton, ActiveRandomizeButton},
-                                    {sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), IdleInstructionsButton, ReadyInstructionsButton}};
+                                    {sf::Vector2f(21 * 5, 84 * 5), sf::Vector2f(5, 5), Battleship_},
+                                    {sf::Vector2f(42 * 5, 92 * 5), sf::Vector2f(5, 5), AircraftCarrier_},
+                                    {sf::Vector2f(61 * 5, 100 * 5), sf::Vector2f(5, 5), Destroyer_},
+                                    {sf::Vector2f(61 * 5, 35 * 5), sf::Vector2f(5, 5), Submarine_},
+                                    {sf::Vector2f(42 * 5, 43 * 5), sf::Vector2f(5, 5), PatrolBoat_},
+                                    {sf::Vector2f(21 * 5, 51 * 5), sf::Vector2f(5, 5), RowBoat_}};
+    const vector<button> buttons = {{sf::Vector2f(320 * 5, 124 * 5), sf::Vector2f(5, 5), IdleReadyButton, ActiveReadyButton},
+                                    {sf::Vector2f(328 * 5, 76 * 5), sf::Vector2f(5, 5), IdleRandomizeButton, ActiveRandomizeButton},
+                                    {sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), IdleInstructionsButton, ReadyInstructionsButton}};
 
     this->resources = ScreenResourceManager(texturePaths, sprites, buttons);
 
     this->layoutGenerated = false;
 
 
+    //    loadTexture(this->fleetPlacementDefaultBackgroundTexture, "fleetPlacement/FleetPlacementBackground.png");
+    //    loadTexture(this->fleetPlacementP1BackgroundTexture, "fleetPlacement/FleetPlacementP1Background.png");
+    //    loadTexture(this->fleetPlacementP2BackgroundTexture, "fleetPlacement/FleetPlacementP2Background.png");
+    //
+    //    loadTexture(this->idleReadyButtonTexture, "fleetPlacement/IdleReadyButton.png");
+    //    loadTexture(this->activeReadyButtonTexture, "fleetPlacement/ActiveReadyButton.png");
+    //    loadTexture(this->idleRandomizeButtonTexture, "fleetPlacement/IdleRandomizeButton.png");
+    //    loadTexture(this->activeRandomizeButtonTexture, "fleetPlacement/ActiveRandomizeButton.png");
+    //    loadTexture(this->idleInstructionsButtonTexture, "fleetPlacement/IdleInstructionsButton.png");
+    //    loadTexture(this->activeInstructionsButtonTexture, "fleetPlacement/ActiveInstructionsButton.png");
+    //
+    //    loadTexture(this->battleshipTexture, "fleetPlacement/BattleShip.png");
+    //    loadTexture(this->aircraftCarrierTexture, "fleetPlacement/AircraftCarrier.png");
+    //    loadTexture(this->destroyerTexture, "fleetPlacement/Destroyer.png");
+    //    loadTexture(this->submarineTexture, "fleetPlacement/Submarine.png");
+    //    loadTexture(this->patrolBoatTexture, "fleetPlacement/PatrolBoat.png");
+    //    loadTexture(this->rowBoatTexture, "fleetPlacement/RowBoat.png");
 
-    loadTexture(this->fleetPlacementDefaultBackgroundTexture, "fleetPlacement/FleetPlacementBackground.png");
-    loadTexture(this->fleetPlacementP1BackgroundTexture, "fleetPlacement/FleetPlacementP1Background.png");
-    loadTexture(this->fleetPlacementP2BackgroundTexture, "fleetPlacement/FleetPlacementP2Background.png");
-
-    loadTexture(this->idleReadyButtonTexture, "fleetPlacement/IdleReadyButton.png");
-    loadTexture(this->activeReadyButtonTexture, "fleetPlacement/ActiveReadyButton.png");
-    loadTexture(this->idleRandomizeButtonTexture, "fleetPlacement/IdleRandomizeButton.png");
-    loadTexture(this->activeRandomizeButtonTexture, "fleetPlacement/ActiveRandomizeButton.png");
-    loadTexture(this->idleInstructionsButtonTexture, "fleetPlacement/IdleInstructionsButton.png");
-    loadTexture(this->activeInstructionsButtonTexture, "fleetPlacement/ActiveInstructionsButton.png");
-
-    loadTexture(this->battleshipTexture, "fleetPlacement/BattleShip.png");
-    loadTexture(this->aircraftCarrierTexture, "fleetPlacement/AircraftCarrier.png");
-    loadTexture(this->destroyerTexture, "fleetPlacement/Destroyer.png");
-    loadTexture(this->submarineTexture, "fleetPlacement/Submarine.png");
-    loadTexture(this->patrolBoatTexture, "fleetPlacement/PatrolBoat.png");
-    loadTexture(this->rowBoatTexture, "fleetPlacement/RowBoat.png");
-
-    setSprite(sf::Vector2f(0, 0), sf::Vector2f(5, 5), this->fleetPlacementDefaultBackgroundTexture, this->backgroundDefaultSprite);
-    setSprite(sf::Vector2f(0, 0), sf::Vector2f(5, 5), this->fleetPlacementP1BackgroundTexture, this->backgroundP1Sprite);
-    setSprite(sf::Vector2f(0, 0), sf::Vector2f(5, 5), this->fleetPlacementP2BackgroundTexture, this->backgroundP2Sprite);
-
-    setSprite(sf::Vector2f(21 * 5, 84 * 5), sf::Vector2f(5, 5), this->battleshipTexture, this->battleshipSprite);
-    setSprite(sf::Vector2f(42 * 5, 92 * 5), sf::Vector2f(5, 5), this->aircraftCarrierTexture, this->aircraftCarrierSprite);
-    setSprite(sf::Vector2f(61 * 5, 100 * 5), sf::Vector2f(5, 5), this->destroyerTexture, this->destroyerSprite);
-    setSprite(sf::Vector2f(61 * 5, 35 * 5), sf::Vector2f(5, 5), this->submarineTexture, this->submarineSprite);
-    setSprite(sf::Vector2f(42 * 5, 43 * 5), sf::Vector2f(5, 5), this->patrolBoatTexture, this->patrolBoatSprite);
-    setSprite(sf::Vector2f(21 * 5, 51 * 5), sf::Vector2f(5, 5), this->rowBoatTexture, this->rowBoatSprite);
-
-    this->readyButton = new Button(sf::Vector2f(320 * 5, 124 * 5), sf::Vector2f(5, 5), this->idleReadyButtonTexture, this->activeReadyButtonTexture);
-    this->randomizeButton = new Button(sf::Vector2f(328 * 5, 76 * 5), sf::Vector2f(5, 5), this->idleRandomizeButtonTexture, this->activeRandomizeButtonTexture);
-    this->instructionsButton = new Button(sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), this->idleInstructionsButtonTexture, this->activeInstructionsButtonTexture);
+    //    setSprite(sf::Vector2f(0, 0), sf::Vector2f(5, 5), this->fleetPlacementDefaultBackgroundTexture, this->backgroundDefaultSprite);
+    //    setSprite(sf::Vector2f(0, 0), sf::Vector2f(5, 5), this->fleetPlacementP1BackgroundTexture, this->backgroundP1Sprite);
+    //    setSprite(sf::Vector2f(0, 0), sf::Vector2f(5, 5), this->fleetPlacementP2BackgroundTexture, this->backgroundP2Sprite);
+    //
+    //    setSprite(sf::Vector2f(21 * 5, 84 * 5), sf::Vector2f(5, 5), this->battleshipTexture, this->battleshipSprite);
+    //    setSprite(sf::Vector2f(42 * 5, 92 * 5), sf::Vector2f(5, 5), this->aircraftCarrierTexture, this->aircraftCarrierSprite);
+    //    setSprite(sf::Vector2f(61 * 5, 100 * 5), sf::Vector2f(5, 5), this->destroyerTexture, this->destroyerSprite);
+    //    setSprite(sf::Vector2f(61 * 5, 35 * 5), sf::Vector2f(5, 5), this->submarineTexture, this->submarineSprite);
+    //    setSprite(sf::Vector2f(42 * 5, 43 * 5), sf::Vector2f(5, 5), this->patrolBoatTexture, this->patrolBoatSprite);
+    //    setSprite(sf::Vector2f(21 * 5, 51 * 5), sf::Vector2f(5, 5), this->rowBoatTexture, this->rowBoatSprite);
+    //
+    //    this->readyButton = new Button(sf::Vector2f(320 * 5, 124 * 5), sf::Vector2f(5, 5), this->idleReadyButtonTexture, this->activeReadyButtonTexture);
+    //    this->randomizeButton = new Button(sf::Vector2f(328 * 5, 76 * 5), sf::Vector2f(5, 5), this->idleRandomizeButtonTexture, this->activeRandomizeButtonTexture);
+    //    this->instructionsButton = new Button(sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), this->idleInstructionsButtonTexture, this->activeInstructionsButtonTexture);
 }
 
 void FleetPlacement::addCoord(vector<Coordinate> &coordinates, int x, int y) {
@@ -90,6 +89,7 @@ void FleetPlacement::randomize() {
     }
 
     // Find spots for the ships (start with the big ships to speed it up)
+    // TODO: Move this to a field
     static shipNames allShips[6] = {
             shipNames::BATTLESHIP,
             shipNames::AIRCRAFT_CARRIER,
@@ -158,92 +158,101 @@ void FleetPlacement::randomize() {
 }
 
 void FleetPlacement::updateFleetLayout() {
+    sf::Sprite *battleship = &resources.getSprite(Battleship);
+    sf::Sprite *aircraftCarrier = &resources.getSprite(AircraftCarrier);
+    sf::Sprite *destroyer = &resources.getSprite(Destroyer);
+    sf::Sprite *submarine = &resources.getSprite(Submarine);
+    sf::Sprite *patrolBoat = &resources.getSprite(PatrolBoat);
+    sf::Sprite *rowBoat = &resources.getSprite(RowBoat);
+
     if (get<1>(this->ships[shipNames::BATTLESHIP]) == 1) {
-        this->battleshipSprite.setPosition(sf::Vector2f((224 + (get<0>(this->ships[shipNames::BATTLESHIP]).getX() * 16)) * 5,
-                                                        (28 + (get<0>(this->ships[shipNames::BATTLESHIP]).getY() * 16)) * 5));
-        this->battleshipSprite.setRotation(90.f);
+        battleship->setPosition(sf::Vector2f((224 + (get<0>(this->ships[shipNames::BATTLESHIP]).getX() * 16)) * 5,
+                                            (28 + (get<0>(this->ships[shipNames::BATTLESHIP]).getY() * 16)) * 5));
+        battleship->setRotation(90.f);
     } else {
-        this->battleshipSprite.setPosition(sf::Vector2f((128 + (get<0>(this->ships[shipNames::BATTLESHIP]).getX() * 16)) * 5,
-                                                        (28 + (get<0>(this->ships[shipNames::BATTLESHIP]).getY() * 16)) * 5));
-        this->battleshipSprite.setRotation(0);
+        battleship->setPosition(sf::Vector2f((128 + (get<0>(this->ships[shipNames::BATTLESHIP]).getX() * 16)) * 5,
+                                            (28 + (get<0>(this->ships[shipNames::BATTLESHIP]).getY() * 16)) * 5));
+        battleship->setRotation(0);
     }
 
     if (get<1>(this->ships[shipNames::AIRCRAFT_CARRIER]) == 1) {
-        this->aircraftCarrierSprite.setPosition(sf::Vector2f((208 + (get<0>(this->ships[shipNames::AIRCRAFT_CARRIER]).getX() * 16)) * 5,
-                                                             (28 + (get<0>(this->ships[shipNames::AIRCRAFT_CARRIER]).getY() * 16)) * 5));
-        this->aircraftCarrierSprite.setRotation(90.f);
+        aircraftCarrier->setPosition(sf::Vector2f((208 + (get<0>(this->ships[shipNames::AIRCRAFT_CARRIER]).getX() * 16)) * 5,
+                                                 (28 + (get<0>(this->ships[shipNames::AIRCRAFT_CARRIER]).getY() * 16)) * 5));
+        aircraftCarrier->setRotation(90.f);
     } else {
-        this->aircraftCarrierSprite.setPosition(sf::Vector2f((128 + (get<0>(this->ships[shipNames::AIRCRAFT_CARRIER]).getX() * 16)) * 5,
-                                                             (28 + (get<0>(this->ships[shipNames::AIRCRAFT_CARRIER]).getY() * 16)) * 5));
-        this->aircraftCarrierSprite.setRotation(0);
+        aircraftCarrier->setPosition(sf::Vector2f((128 + (get<0>(this->ships[shipNames::AIRCRAFT_CARRIER]).getX() * 16)) * 5,
+                                                 (28 + (get<0>(this->ships[shipNames::AIRCRAFT_CARRIER]).getY() * 16)) * 5));
+        aircraftCarrier->setRotation(0);
     }
 
     if (get<1>(this->ships[shipNames::DESTROYER]) == 1) {
-        this->destroyerSprite.setPosition(sf::Vector2f((192 + (get<0>(this->ships[shipNames::DESTROYER]).getX() * 16)) * 5,
-                                                       (28 + (get<0>(this->ships[shipNames::DESTROYER]).getY() * 16)) * 5));
-        this->destroyerSprite.setRotation(90.f);
+        destroyer
+                ->setPosition(sf::Vector2f((192 + (get<0>(this->ships[shipNames::DESTROYER]).getX() * 16)) * 5,
+                                          (28 + (get<0>(this->ships[shipNames::DESTROYER]).getY() * 16)) * 5));
+        destroyer->setRotation(90.f);
     } else {
-        this->destroyerSprite.setPosition(sf::Vector2f((128 + (get<0>(this->ships[shipNames::DESTROYER]).getX() * 16)) * 5,
-                                                       (28 + (get<0>(this->ships[shipNames::DESTROYER]).getY() * 16)) * 5));
-        this->destroyerSprite.setRotation(0);
+        destroyer->setPosition(sf::Vector2f((128 + (get<0>(this->ships[shipNames::DESTROYER]).getX() * 16)) * 5,
+                                           (28 + (get<0>(this->ships[shipNames::DESTROYER]).getY() * 16)) * 5));
+        destroyer->setRotation(0);
     }
 
     if (get<1>(this->ships[shipNames::SUBMARINE]) == 1) {
-        this->submarineSprite.setPosition(sf::Vector2f((176 + (get<0>(this->ships[shipNames::SUBMARINE]).getX() * 16)) * 5,
-                                                       (28 + (get<0>(this->ships[shipNames::SUBMARINE]).getY() * 16)) * 5));
-        this->submarineSprite.setRotation(90.f);
+        submarine->setPosition(sf::Vector2f((176 + (get<0>(this->ships[shipNames::SUBMARINE]).getX() * 16)) * 5,
+                                           (28 + (get<0>(this->ships[shipNames::SUBMARINE]).getY() * 16)) * 5));
+        submarine->setRotation(90.f);
     } else {
-        this->submarineSprite.setPosition(sf::Vector2f((128 + (get<0>(this->ships[shipNames::SUBMARINE]).getX() * 16)) * 5,
-                                                       (28 + (get<0>(this->ships[shipNames::SUBMARINE]).getY() * 16)) * 5));
-        this->submarineSprite.setRotation(0);
+        submarine->setPosition(sf::Vector2f((128 + (get<0>(this->ships[shipNames::SUBMARINE]).getX() * 16)) * 5,
+                                           (28 + (get<0>(this->ships[shipNames::SUBMARINE]).getY() * 16)) * 5));
+        submarine->setRotation(0);
     }
 
     if (get<1>(this->ships[shipNames::PATROL_BOAT]) == 1) {
-        this->patrolBoatSprite.setPosition(sf::Vector2f((160 + (get<0>(this->ships[shipNames::PATROL_BOAT]).getX() * 16)) * 5,
-                                                        (28 + (get<0>(this->ships[shipNames::PATROL_BOAT]).getY() * 16)) * 5));
-        this->patrolBoatSprite.setRotation(90.f);
+        patrolBoat->setPosition(sf::Vector2f((160 + (get<0>(this->ships[shipNames::PATROL_BOAT]).getX() * 16)) * 5,
+                                            (28 + (get<0>(this->ships[shipNames::PATROL_BOAT]).getY() * 16)) * 5));
+        patrolBoat->setRotation(90.f);
     } else {
-        this->patrolBoatSprite.setPosition(sf::Vector2f((128 + (get<0>(this->ships[shipNames::PATROL_BOAT]).getX() * 16)) * 5,
-                                                        (28 + (get<0>(this->ships[shipNames::PATROL_BOAT]).getY() * 16)) * 5));
-        this->patrolBoatSprite.setRotation(0);
+        patrolBoat->setPosition(sf::Vector2f((128 + (get<0>(this->ships[shipNames::PATROL_BOAT]).getX() * 16)) * 5,
+                                            (28 + (get<0>(this->ships[shipNames::PATROL_BOAT]).getY() * 16)) * 5));
+        patrolBoat->setRotation(0);
     }
 
     if (get<1>(this->ships[shipNames::ROW_BOAT]) == 1) {
-        this->rowBoatSprite.setPosition(sf::Vector2f((144 + (get<0>(this->ships[shipNames::ROW_BOAT]).getX() * 16)) * 5,
-                                                     (28 + (get<0>(this->ships[shipNames::ROW_BOAT]).getY() * 16)) * 5));
-        this->rowBoatSprite.setRotation(90.0);
+        rowBoat->setPosition(sf::Vector2f((144 + (get<0>(this->ships[shipNames::ROW_BOAT]).getX() * 16)) * 5,
+                                         (28 + (get<0>(this->ships[shipNames::ROW_BOAT]).getY() * 16)) * 5));
+        rowBoat->setRotation(90.0);
     } else {
-        this->rowBoatSprite.setPosition(sf::Vector2f((128 + (get<0>(this->ships[shipNames::ROW_BOAT]).getX() * 16)) * 5,
-                                                     (28 + (get<0>(this->ships[shipNames::ROW_BOAT]).getY() * 16)) * 5));
-        this->rowBoatSprite.setRotation(0);
+        rowBoat->setPosition(sf::Vector2f((128 + (get<0>(this->ships[shipNames::ROW_BOAT]).getX() * 16)) * 5,
+                                         (28 + (get<0>(this->ships[shipNames::ROW_BOAT]).getY() * 16)) * 5));
+        rowBoat->setRotation(0);
     }
 }
 
 void FleetPlacement::resetFleetLayout() {
-    this->battleshipSprite.setPosition(sf::Vector2f(21 * 5, 84 * 5));
-    this->battleshipSprite.setRotation(0);
+    resources.getSprite(Battleship).setPosition(sf::Vector2f(21 * 5, 84 * 5));
+    resources.getSprite(Battleship).setRotation(0);
 
-    this->aircraftCarrierSprite.setPosition(sf::Vector2f(42 * 5, 92 * 5));
-    this->aircraftCarrierSprite.setRotation(0);
+    resources.getSprite(AircraftCarrier).setPosition(sf::Vector2f(42 * 5, 92 * 5));
+    resources.getSprite(AircraftCarrier).setRotation(0);
 
-    this->destroyerSprite.setPosition(sf::Vector2f(61 * 5, 100 * 5));
-    this->destroyerSprite.setRotation(0);
+    resources.getSprite(Destroyer).setPosition(sf::Vector2f(61 * 5, 100 * 5));
+    resources.getSprite(Destroyer).setRotation(0);
 
-    this->submarineSprite.setPosition(sf::Vector2f(61 * 5, 35 * 5));
-    this->submarineSprite.setRotation(0);
+    resources.getSprite(Submarine).setPosition(sf::Vector2f(61 * 5, 35 * 5));
+    resources.getSprite(Submarine).setRotation(0);
 
-    this->patrolBoatSprite.setPosition(sf::Vector2f(42 * 5, 43 * 5));
-    this->patrolBoatSprite.setRotation(0);
+    resources.getSprite(PatrolBoat).setPosition(sf::Vector2f(42 * 5, 43 * 5));
+    resources.getSprite(PatrolBoat).setRotation(0);
 
-    this->rowBoatSprite.setPosition(sf::Vector2f(21 * 5, 51 * 5));
-    this->rowBoatSprite.setRotation(0);
+    resources.getSprite(RowBoat).setPosition(sf::Vector2f(21 * 5, 51 * 5));
+    resources.getSprite(RowBoat).setRotation(0);
 }
 
 void FleetPlacement::update() {
     sf::Vector2f mousePosition = State::getMousePosition();
-    this->readyButton->updateButtonState(mousePosition);
-    this->randomizeButton->updateButtonState(mousePosition);
-    this->instructionsButton->updateButtonState(mousePosition);
+
+    resources.getButton(Ready).updateButtonState(mousePosition);
+    resources.getButton(Randomize).updateButtonState(mousePosition);
+    resources.getButton(Instructions).updateButtonState(mousePosition);
 }
 
 void FleetPlacement::poll() {
@@ -258,7 +267,7 @@ void FleetPlacement::poll() {
                 break;
 
             case sf::Event::MouseButtonReleased:
-                if ((event.mouseButton.button == sf::Mouse::Left) && (this->readyButton->getButtonState())) {
+                if ((event.mouseButton.button == sf::Mouse::Left) && (resources.getButton(Ready).getButtonState())) {
                     if (State::gameMode == State::GameMode::SINGLE_PLAYER) {
                         Gameplay::setP1Grid(ships);
                         this->resetFleetLayout();
@@ -284,12 +293,12 @@ void FleetPlacement::poll() {
                             break;
                         }
                     }
-                } else if ((event.mouseButton.button == sf::Mouse::Left) && (this->randomizeButton->getButtonState())) {
+                } else if ((event.mouseButton.button == sf::Mouse::Left) && (resources.getButton(Randomize).getButtonState())) {
                     this->randomize();
                     this->updateFleetLayout();
                     this->layoutGenerated = true;
                     break;
-                } else if ((event.mouseButton.button == sf::Mouse::Left) && (this->instructionsButton->getButtonState())) {
+                } else if ((event.mouseButton.button == sf::Mouse::Left) && (resources.getButton(Instructions).getButtonState())) {
                     State::changeScreen(Screens::INSTRUCTIONS);
                     break;
                 } else {
@@ -307,28 +316,28 @@ void FleetPlacement::render() {
     gui.clear();
 
     if (State::gameMode == State::SINGLE_PLAYER) {
-        gui.draw(this->backgroundDefaultSprite);
+        gui.draw(resources.getSprite(BackgroundDefault));
     } else {
         if (State::player == State::Player::P1) {
-            gui.draw(this->backgroundP1Sprite);
+            gui.draw(resources.getSprite(BackgroundP1));
         } else {
-            gui.draw(this->backgroundP2Sprite);
+            gui.draw(resources.getSprite(BackgroundP2));
         }
     }
 
     if (layoutGenerated) {
-        readyButton->render(gui);
+        resources.getButton(Ready).render(gui);
     }
 
-    randomizeButton->render(gui);
-    instructionsButton->render(gui);
+    resources.getButton(Randomize).render(gui);
+    resources.getButton(Instructions).render(gui);
 
-    gui.draw(this->battleshipSprite);
-    gui.draw(this->aircraftCarrierSprite);
-    gui.draw(this->destroyerSprite);
-    gui.draw(this->submarineSprite);
-    gui.draw(this->patrolBoatSprite);
-    gui.draw(this->rowBoatSprite);
+    gui.draw(resources.getSprite(Battleship));
+    gui.draw(resources.getSprite(AircraftCarrier));
+    gui.draw(resources.getSprite(Destroyer));
+    gui.draw(resources.getSprite(Submarine));
+    gui.draw(resources.getSprite(PatrolBoat));
+    gui.draw(resources.getSprite(RowBoat));
 
     if (State::getCurrentScreen() == Screens::FLEET_PLACEMENT) {
         gui.display();

--- a/src/screens/fleetPlacement.cpp
+++ b/src/screens/fleetPlacement.cpp
@@ -1,6 +1,5 @@
 /**
- * File: fleetPlacement.cpp
- * Description: Front-end class that defines the behaviour of the Fleet Placement screens
+ * Front-end class that defines the behaviour of the Fleet Placement screens
  */
 
 #include "fleetPlacement.hpp"
@@ -9,9 +8,36 @@
 using screen::FleetPlacement;
 using std::get;
 
-FleetPlacement *FleetPlacement::instance = nullptr;
+std::unique_ptr<FleetPlacement> FleetPlacement::instance = nullptr;
 
 FleetPlacement::FleetPlacement() : ScreenTemplate() {
+    const vector<string> texturePaths = {"fleetPlacement/FleetPlacementBackground.png", "fleetPlacement/FleetPlacementP1Background.png",
+                                         "fleetPlacement/FleetPlacementP2Background.png",
+                                         "fleetPlacement/IdleReadyButton.png", "fleetPlacement/ActiveReadyButton.png",
+                                         "fleetPlacement/IdleRandomizeButton.png", "fleetPlacement/ActiveRandomizeButton.png",
+                                         "fleetPlacement/IdleInstructionsButton.png", "fleetPlacement/ActiveInstructionsButton.png",
+                                         "fleetPlacement/BattleShip.png", "fleetPlacement/AircraftCarrier.png",
+                                         "fleetPlacement/Destroyer.png", "fleetPlacement/Submarine.png",
+                                         "fleetPlacement/PatrolBoat.png", "fleetPlacement/RowBoat.png"};
+    const vector<sprite> sprites = {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), BackgroundDefault_},
+                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), BackgroundP1_},
+                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), BackgroundP2_},
+                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), Battleship_},
+                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), AircraftCarrier_},
+                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), Destroyer_},
+                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), Submarine_},
+                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), PatrolBoat_},
+                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), RowBoat_}};
+    const vector<button> buttons = {{sf::Vector2f(88 * 5, 92 * 5), sf::Vector2f(5, 5), IdleReadyButton, ActiveReadyButton},
+                                    {sf::Vector2f(200 * 5, 92 * 5), sf::Vector2f(5, 5), IdleRandomizeButton, ActiveRandomizeButton},
+                                    {sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), IdleInstructionsButton, ReadyInstructionsButton}};
+
+    this->resources = ScreenResourceManager(texturePaths, sprites, buttons);
+
+    this->layoutGenerated = false;
+
+
+
     loadTexture(this->fleetPlacementDefaultBackgroundTexture, "fleetPlacement/FleetPlacementBackground.png");
     loadTexture(this->fleetPlacementP1BackgroundTexture, "fleetPlacement/FleetPlacementP1Background.png");
     loadTexture(this->fleetPlacementP2BackgroundTexture, "fleetPlacement/FleetPlacementP2Background.png");
@@ -44,8 +70,6 @@ FleetPlacement::FleetPlacement() : ScreenTemplate() {
     this->readyButton = new Button(sf::Vector2f(320 * 5, 124 * 5), sf::Vector2f(5, 5), this->idleReadyButtonTexture, this->activeReadyButtonTexture);
     this->randomizeButton = new Button(sf::Vector2f(328 * 5, 76 * 5), sf::Vector2f(5, 5), this->idleRandomizeButtonTexture, this->activeRandomizeButtonTexture);
     this->instructionsButton = new Button(sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), this->idleInstructionsButtonTexture, this->activeInstructionsButtonTexture);
-
-    this->layoutGenerated = false;
 }
 
 void FleetPlacement::addCoord(vector<Coordinate> &coordinates, int x, int y) {
@@ -313,7 +337,7 @@ void FleetPlacement::render() {
 
 FleetPlacement &screen::FleetPlacement::getInstance() {
     if (instance == nullptr) {
-        instance = new FleetPlacement();
+        instance.reset(new FleetPlacement());
     }
     return *instance;
 }

--- a/src/screens/fleetPlacement.cpp
+++ b/src/screens/fleetPlacement.cpp
@@ -227,31 +227,30 @@ void FleetPlacement::poll() {
 
     while (gui.pollEvent(event)) {
         switch (event.type) {
-
             case sf::Event::Closed:
                 gui.close();
                 break;
-
             case sf::Event::MouseButtonReleased:
                 if ((event.mouseButton.button == sf::Mouse::Left) && (resources.getButton(Ready).getButtonState())) {
+                    Gameplay *gameplayInstance = &Gameplay::getInstance();
                     if (State::gameMode == State::GameMode::SINGLE_PLAYER) {
-                        Gameplay::setP1Grid(ships);
+                        gameplayInstance->setP1Grid(ships);
                         this->resetFleetLayout();
                         this->layoutGenerated = false;
                         this->randomize();
-                        Gameplay::setP2Grid(ships);
+                        gameplayInstance->setP2Grid(ships);
                         State::changeScreen(Screens::GAMEPLAY);
                         break;
                     } else {
                         if (State::player == State::Player::P1) {
-                            Gameplay::setP1Grid(ships);
+                            gameplayInstance->setP1Grid(ships);
                             this->resetFleetLayout();
                             this->layoutGenerated = false;
                             State::player = State::Player::P2;
                             State::changeScreen(Screens::INTERMEDIARY);
                             break;
                         } else {
-                            Gameplay::setP2Grid(ships);
+                            gameplayInstance->setP2Grid(ships);
                             this->resetFleetLayout();
                             this->layoutGenerated = false;
                             State::player = State::Player::P1;
@@ -270,7 +269,6 @@ void FleetPlacement::poll() {
                 } else {
                     break;
                 }
-
             default:
                 break;
         }

--- a/src/screens/fleetPlacement.cpp
+++ b/src/screens/fleetPlacement.cpp
@@ -4,7 +4,6 @@
  */
 
 #include "fleetPlacement.hpp"
-#include "../helpers/helperFunctions.hpp"
 #include "gameplay.hpp"
 
 using screen::FleetPlacement;
@@ -310,12 +309,6 @@ void FleetPlacement::render() {
     if (State::getCurrentScreen() == Screens::FLEET_PLACEMENT) {
         gui.display();
     }
-}
-
-void FleetPlacement::run() {
-    this->update();
-    this->poll();
-    this->render();
 }
 
 FleetPlacement &screen::FleetPlacement::getInstance() {

--- a/src/screens/fleetPlacement.cpp
+++ b/src/screens/fleetPlacement.cpp
@@ -35,40 +35,6 @@ FleetPlacement::FleetPlacement() : ScreenTemplate() {
     this->resources = ScreenResourceManager(texturePaths, sprites, buttons);
 
     this->layoutGenerated = false;
-
-
-    //    loadTexture(this->fleetPlacementDefaultBackgroundTexture, "fleetPlacement/FleetPlacementBackground.png");
-    //    loadTexture(this->fleetPlacementP1BackgroundTexture, "fleetPlacement/FleetPlacementP1Background.png");
-    //    loadTexture(this->fleetPlacementP2BackgroundTexture, "fleetPlacement/FleetPlacementP2Background.png");
-    //
-    //    loadTexture(this->idleReadyButtonTexture, "fleetPlacement/IdleReadyButton.png");
-    //    loadTexture(this->activeReadyButtonTexture, "fleetPlacement/ActiveReadyButton.png");
-    //    loadTexture(this->idleRandomizeButtonTexture, "fleetPlacement/IdleRandomizeButton.png");
-    //    loadTexture(this->activeRandomizeButtonTexture, "fleetPlacement/ActiveRandomizeButton.png");
-    //    loadTexture(this->idleInstructionsButtonTexture, "fleetPlacement/IdleInstructionsButton.png");
-    //    loadTexture(this->activeInstructionsButtonTexture, "fleetPlacement/ActiveInstructionsButton.png");
-    //
-    //    loadTexture(this->battleshipTexture, "fleetPlacement/BattleShip.png");
-    //    loadTexture(this->aircraftCarrierTexture, "fleetPlacement/AircraftCarrier.png");
-    //    loadTexture(this->destroyerTexture, "fleetPlacement/Destroyer.png");
-    //    loadTexture(this->submarineTexture, "fleetPlacement/Submarine.png");
-    //    loadTexture(this->patrolBoatTexture, "fleetPlacement/PatrolBoat.png");
-    //    loadTexture(this->rowBoatTexture, "fleetPlacement/RowBoat.png");
-
-    //    setSprite(sf::Vector2f(0, 0), sf::Vector2f(5, 5), this->fleetPlacementDefaultBackgroundTexture, this->backgroundDefaultSprite);
-    //    setSprite(sf::Vector2f(0, 0), sf::Vector2f(5, 5), this->fleetPlacementP1BackgroundTexture, this->backgroundP1Sprite);
-    //    setSprite(sf::Vector2f(0, 0), sf::Vector2f(5, 5), this->fleetPlacementP2BackgroundTexture, this->backgroundP2Sprite);
-    //
-    //    setSprite(sf::Vector2f(21 * 5, 84 * 5), sf::Vector2f(5, 5), this->battleshipTexture, this->battleshipSprite);
-    //    setSprite(sf::Vector2f(42 * 5, 92 * 5), sf::Vector2f(5, 5), this->aircraftCarrierTexture, this->aircraftCarrierSprite);
-    //    setSprite(sf::Vector2f(61 * 5, 100 * 5), sf::Vector2f(5, 5), this->destroyerTexture, this->destroyerSprite);
-    //    setSprite(sf::Vector2f(61 * 5, 35 * 5), sf::Vector2f(5, 5), this->submarineTexture, this->submarineSprite);
-    //    setSprite(sf::Vector2f(42 * 5, 43 * 5), sf::Vector2f(5, 5), this->patrolBoatTexture, this->patrolBoatSprite);
-    //    setSprite(sf::Vector2f(21 * 5, 51 * 5), sf::Vector2f(5, 5), this->rowBoatTexture, this->rowBoatSprite);
-    //
-    //    this->readyButton = new Button(sf::Vector2f(320 * 5, 124 * 5), sf::Vector2f(5, 5), this->idleReadyButtonTexture, this->activeReadyButtonTexture);
-    //    this->randomizeButton = new Button(sf::Vector2f(328 * 5, 76 * 5), sf::Vector2f(5, 5), this->idleRandomizeButtonTexture, this->activeRandomizeButtonTexture);
-    //    this->instructionsButton = new Button(sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), this->idleInstructionsButtonTexture, this->activeInstructionsButtonTexture);
 }
 
 void FleetPlacement::addCoord(vector<Coordinate> &coordinates, int x, int y) {

--- a/src/screens/fleetPlacement.hpp
+++ b/src/screens/fleetPlacement.hpp
@@ -1,6 +1,5 @@
 /**
- * File: fleetPlacement.h
- * Description: Front-end class that defines the behaviour of the Fleet Placement screens
+ * Front-end class that defines the behaviour of the Fleet Placement screens
  */
 
 #ifndef BATTLESHIP_FLEETPLACEMENT_H
@@ -23,142 +22,103 @@ using std::vector;
 
 namespace screen {
     class FleetPlacement : public ScreenTemplate {
+    public:
+        /**
+         * Copy constructor
+         */
+        FleetPlacement(const FleetPlacement &source) = delete;
+
+        /**
+         * Overloaded assignment operator
+         */
+        FleetPlacement &operator=(const FleetPlacement &source) = delete;
+
+        /**
+         *
+         */
+        static FleetPlacement &getInstance();
+
     private:
-        /**
-         * Default background texture
-         */
+        // Singleton instance
+        static std::unique_ptr<FleetPlacement> instance;
+
+        // Singleton constructor
+        FleetPlacement();
+
+        // SFML event loop helpers
+        void update() override;
+        void poll() override;
+        void render() override;
+
+        // Names to refer to resources on this screen
+        enum textureNames {
+            BackgroundDefault_,
+            BackgroundP1_,
+            BackgroundP2_,
+            IdleReadyButton,
+            ActiveReadyButton,
+            IdleRandomizeButton,
+            ActiveRandomizeButton,
+            IdleInstructionsButton,
+            ReadyInstructionsButton,
+            Battleship_,
+            AircraftCarrier_,
+            Destroyer_,
+            Submarine_,
+            PatrolBoat_,
+            RowBoat_
+        };
+        enum spriteNames {
+            BackgroundDefault,
+            BackgroundP1,
+            BackgroundP2,
+            Battleship,
+            AircraftCarrier,
+            Destroyer,
+            Submarine,
+            PatrolBoat,
+            RowBoat
+        };
+        enum buttonNames {
+            Ready,
+            Randomize,
+            Instructions
+        };
+
         sf::Texture fleetPlacementDefaultBackgroundTexture;
-
-        /**
-         * P1 background texture
-         */
         sf::Texture fleetPlacementP1BackgroundTexture;
-
-        /**
-         * P2 background texture
-         */
         sf::Texture fleetPlacementP2BackgroundTexture;
-
-        /**
-         * Idle ready button texture
-         */
         sf::Texture idleReadyButtonTexture;
-
-        /**
-         * Active ready button texture
-         */
         sf::Texture activeReadyButtonTexture;
-
-        /**
-         * Idle randomize button texture
-         */
         sf::Texture idleRandomizeButtonTexture;
-
-        /**
-         * Active randomize button texture
-         */
         sf::Texture activeRandomizeButtonTexture;
-
-        /**
-         * Idle instructions button texture
-         */
         sf::Texture idleInstructionsButtonTexture;
-
-        /**
-         * Active instructions button texture
-         */
         sf::Texture activeInstructionsButtonTexture;
-
-        /**
-         * Battleship texture
-         */
         sf::Texture battleshipTexture;
-
-        /**
-         * Aircraft carrier texture
-         */
         sf::Texture aircraftCarrierTexture;
-
-        /**
-         * Destroyer texture
-         */
         sf::Texture destroyerTexture;
-
-        /**
-         * Submarine texture
-         */
         sf::Texture submarineTexture;
-
-        /**
-         * Patrol boat texture
-         */
         sf::Texture patrolBoatTexture;
-
-        /**
-         * Row boat texture
-         */
         sf::Texture rowBoatTexture;
 
-        /**
-         * Background default sprite
-         */
         sf::Sprite backgroundDefaultSprite;
-
-        /**
-         * Background P1 sprite
-         */
         sf::Sprite backgroundP1Sprite;
-
-        /**
-         * Background P2 sprite
-         */
         sf::Sprite backgroundP2Sprite;
-
-        /**
-         * Battleship sprite
-         */
         sf::Sprite battleshipSprite;
-
-        /**
-         * Aircraft carrier sprite
-         */
         sf::Sprite aircraftCarrierSprite;
-
-        /**
-         * Destroyer sprite
-         */
         sf::Sprite destroyerSprite;
-
-        /**
-         * Submarine sprite
-         */
         sf::Sprite submarineSprite;
-
-        /**
-         * Patrol Boat sprite
-         */
         sf::Sprite patrolBoatSprite;
-
-        /**
-         * Row boat sprite
-         */
         sf::Sprite rowBoatSprite;
 
-        /**
-         * Ready button
-         */
         Button *readyButton;
-
-        /**
-         * Randomize button
-         */
         Button *randomizeButton;
-
-        /**
-         * Instructions button
-         */
         Button *instructionsButton;
 
+
+        /**
+         *
+         */
         bool layoutGenerated;
 
         /**
@@ -189,46 +149,8 @@ namespace screen {
          */
         void resetFleetLayout();
 
-        /**
-         * Calls helpers::updateMousePosition() and entity::Button::updateButtonState()
-         */
-        void update();
 
-        /**
-         * Polls for system events
-         */
-        void poll();
 
-        /**
-         * Renders all sprites
-         */
-        void render();
-
-        /**
-         * Constructor
-         */
-        FleetPlacement();
-
-        /**
-         *
-         */
-        static FleetPlacement *instance;
-
-    public:
-        /**
-         * Copy constructor
-         */
-        FleetPlacement(const FleetPlacement &source) = delete;
-
-        /**
-         * Overloaded assignment operator
-         */
-        FleetPlacement &operator=(const FleetPlacement &source) = delete;
-
-        /**
-         *
-         */
-        static FleetPlacement &getInstance();
     };
 }// namespace screen
 

--- a/src/screens/fleetPlacement.hpp
+++ b/src/screens/fleetPlacement.hpp
@@ -85,35 +85,35 @@ namespace screen {
             Instructions
         };
 
-        sf::Texture fleetPlacementDefaultBackgroundTexture;
-        sf::Texture fleetPlacementP1BackgroundTexture;
-        sf::Texture fleetPlacementP2BackgroundTexture;
-        sf::Texture idleReadyButtonTexture;
-        sf::Texture activeReadyButtonTexture;
-        sf::Texture idleRandomizeButtonTexture;
-        sf::Texture activeRandomizeButtonTexture;
-        sf::Texture idleInstructionsButtonTexture;
-        sf::Texture activeInstructionsButtonTexture;
-        sf::Texture battleshipTexture;
-        sf::Texture aircraftCarrierTexture;
-        sf::Texture destroyerTexture;
-        sf::Texture submarineTexture;
-        sf::Texture patrolBoatTexture;
-        sf::Texture rowBoatTexture;
-
-        sf::Sprite backgroundDefaultSprite;
-        sf::Sprite backgroundP1Sprite;
-        sf::Sprite backgroundP2Sprite;
-        sf::Sprite battleshipSprite;
-        sf::Sprite aircraftCarrierSprite;
-        sf::Sprite destroyerSprite;
-        sf::Sprite submarineSprite;
-        sf::Sprite patrolBoatSprite;
-        sf::Sprite rowBoatSprite;
-
-        Button *readyButton;
-        Button *randomizeButton;
-        Button *instructionsButton;
+//        sf::Texture fleetPlacementDefaultBackgroundTexture;
+//        sf::Texture fleetPlacementP1BackgroundTexture;
+//        sf::Texture fleetPlacementP2BackgroundTexture;
+//        sf::Texture idleReadyButtonTexture;
+//        sf::Texture activeReadyButtonTexture;
+//        sf::Texture idleRandomizeButtonTexture;
+//        sf::Texture activeRandomizeButtonTexture;
+//        sf::Texture idleInstructionsButtonTexture;
+//        sf::Texture activeInstructionsButtonTexture;
+//        sf::Texture battleshipTexture;
+//        sf::Texture aircraftCarrierTexture;
+//        sf::Texture destroyerTexture;
+//        sf::Texture submarineTexture;
+//        sf::Texture patrolBoatTexture;
+//        sf::Texture rowBoatTexture;
+//
+//        sf::Sprite backgroundDefaultSprite;
+//        sf::Sprite backgroundP1Sprite;
+//        sf::Sprite backgroundP2Sprite;
+//        sf::Sprite battleshipSprite;
+//        sf::Sprite aircraftCarrierSprite;
+//        sf::Sprite destroyerSprite;
+//        sf::Sprite submarineSprite;
+//        sf::Sprite patrolBoatSprite;
+//        sf::Sprite rowBoatSprite;
+//
+//        Button *readyButton;
+//        Button *randomizeButton;
+//        Button *instructionsButton;
 
 
         /**

--- a/src/screens/fleetPlacement.hpp
+++ b/src/screens/fleetPlacement.hpp
@@ -85,37 +85,6 @@ namespace screen {
             Instructions
         };
 
-//        sf::Texture fleetPlacementDefaultBackgroundTexture;
-//        sf::Texture fleetPlacementP1BackgroundTexture;
-//        sf::Texture fleetPlacementP2BackgroundTexture;
-//        sf::Texture idleReadyButtonTexture;
-//        sf::Texture activeReadyButtonTexture;
-//        sf::Texture idleRandomizeButtonTexture;
-//        sf::Texture activeRandomizeButtonTexture;
-//        sf::Texture idleInstructionsButtonTexture;
-//        sf::Texture activeInstructionsButtonTexture;
-//        sf::Texture battleshipTexture;
-//        sf::Texture aircraftCarrierTexture;
-//        sf::Texture destroyerTexture;
-//        sf::Texture submarineTexture;
-//        sf::Texture patrolBoatTexture;
-//        sf::Texture rowBoatTexture;
-//
-//        sf::Sprite backgroundDefaultSprite;
-//        sf::Sprite backgroundP1Sprite;
-//        sf::Sprite backgroundP2Sprite;
-//        sf::Sprite battleshipSprite;
-//        sf::Sprite aircraftCarrierSprite;
-//        sf::Sprite destroyerSprite;
-//        sf::Sprite submarineSprite;
-//        sf::Sprite patrolBoatSprite;
-//        sf::Sprite rowBoatSprite;
-//
-//        Button *readyButton;
-//        Button *randomizeButton;
-//        Button *instructionsButton;
-
-
         /**
          *
          */
@@ -148,8 +117,6 @@ namespace screen {
          * Resets ship sprites and orientations
          */
         void resetFleetLayout();
-
-
 
     };
 }// namespace screen

--- a/src/screens/fleetPlacement.hpp
+++ b/src/screens/fleetPlacement.hpp
@@ -226,11 +226,6 @@ namespace screen {
         FleetPlacement &operator=(const FleetPlacement &source) = delete;
 
         /**
-         * Overridden run method of screenTemplate
-         */
-        void run() override;
-
-        /**
          *
          */
         static FleetPlacement &getInstance();

--- a/src/screens/gameModeSelection.cpp
+++ b/src/screens/gameModeSelection.cpp
@@ -43,30 +43,29 @@ void GameModeSelection::poll() {
 
     while (gui.pollEvent(event)) {
         switch (event.type) {
-
             case sf::Event::Closed:
                 gui.close();
                 break;
-
             case sf::Event::MouseButtonReleased:
-                if ((event.mouseButton.button == sf::Mouse::Left) && (this->onePlayerButton->getButtonState())) {
-                    State::gameMode = State::GameMode::SINGLE_PLAYER;
-                    State::changeScreen(Screens::DIFFICULTY_SELECTION);
-                    break;
-                } else if ((event.mouseButton.button == sf::Mouse::Left) && (this->twoPlayerButton->getButtonState())) {
-                    State::gameMode = State::GameMode::MULTI_PLAYER;
-                    State::changeScreen(Screens::FLEET_PLACEMENT);
-                    break;
-                } else if ((event.mouseButton.button == sf::Mouse::Left) && (this->backButton->getButtonState())) {
-                    State::previousScreen();
-                    break;
-                } else if ((event.mouseButton.button == sf::Mouse::Left) && (this->instructionsButton->getButtonState())) {
-                    State::changeScreen(Screens::INSTRUCTIONS);
-                    break;
-                } else {
-                    break;
+                if (event.mouseButton.button == sf::Mouse::Left) {
+                    if (this->onePlayerButton->getButtonState()) {
+                        State::gameMode = State::GameMode::SINGLE_PLAYER;
+                        State::changeScreen(Screens::DIFFICULTY_SELECTION);
+                        break;
+                    } else if (this->twoPlayerButton->getButtonState()) {
+                        State::gameMode = State::GameMode::MULTI_PLAYER;
+                        State::changeScreen(Screens::FLEET_PLACEMENT);
+                        break;
+                    } else if (this->backButton->getButtonState()) {
+                        State::previousScreen();
+                        break;
+                    } else if (this->instructionsButton->getButtonState()) {
+                        State::changeScreen(Screens::INSTRUCTIONS);
+                        break;
+                    } else {
+                        break;
+                    }
                 }
-
             default:
                 break;
         }

--- a/src/screens/gameModeSelection.cpp
+++ b/src/screens/gameModeSelection.cpp
@@ -88,12 +88,6 @@ void GameModeSelection::render() {
     }
 }
 
-void GameModeSelection::run() {
-    this->update();
-    this->poll();
-    this->render();
-}
-
 GameModeSelection &screen::GameModeSelection::getInstance() {
     if (instance == nullptr) {
         instance = new GameModeSelection();

--- a/src/screens/gameModeSelection.cpp
+++ b/src/screens/gameModeSelection.cpp
@@ -1,40 +1,35 @@
 /**
- * File: gameModeSelection.cpp
- * Description: Front-end class that defines the behaviour of the Game Mode selection screens
+ * Front-end class that defines the behaviour of the Game Mode selection screens
  */
 
 #include "gameModeSelection.hpp"
-#include "../helpers/helperFunctions.hpp"
 
 using screen::GameModeSelection;
 
-GameModeSelection *GameModeSelection::instance = nullptr;
+std::unique_ptr<GameModeSelection> GameModeSelection::instance = nullptr;
 
 GameModeSelection::GameModeSelection() : ScreenTemplate() {
-    loadTexture(this->gameModeBackgroundTexture, "gameModeSelection/GameModeBackground.png");
-    loadTexture(this->idleOnePlayerButtonTexture, "gameModeSelection/Idle1PlayerButton.png");
-    loadTexture(this->activeOnePlayerButtonTexture, "gameModeSelection/Active1PlayerButton.png");
-    loadTexture(this->idleTwoPlayerButtonTexture, "gameModeSelection/Idle2PlayerButton.png");
-    loadTexture(this->activeTwoPlayerButtonTexture, "gameModeSelection/Active2PlayerButton.png");
-    loadTexture(this->idleBackButtonTexture, "gameModeSelection/IdleBackButton.png");
-    loadTexture(this->activeBackButtonTexture, "gameModeSelection/ActiveBackButton.png");
-    loadTexture(this->idleInstructionsButtonTexture, "gameModeSelection/IdleInstructionsButton.png");
-    loadTexture(this->activeInstructionsButtonTexture, "gameModeSelection/ActiveInstructionsButton.png");
+    const vector<string> texturePaths{"gameModeSelection/GameModeBackground.png",
+                                      "gameModeSelection/Idle1PlayerButton.png", "gameModeSelection/Active1PlayerButton.png",
+                                      "gameModeSelection/Idle2PlayerButton.png", "gameModeSelection/Active2PlayerButton.png",
+                                      "gameModeSelection/IdleBackButton.png", "gameModeSelection/ActiveBackButton.png",
+                                      "gameModeSelection/IdleInstructionsButton.png", "gameModeSelection/ActiveInstructionsButton.png"};
+    const vector<sprite> sprites = {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), Background_}};
+    const vector<button> buttons = {{sf::Vector2f(88 * 5, 92 * 5), sf::Vector2f(5, 5), IdleOnePlayer, ActiveOnePlayer},
+                                    {sf::Vector2f(200 * 5, 92 * 5), sf::Vector2f(5, 5), IdleTwoPlayer, ActiveTwoPlayer},
+                                    {sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), IdleBackButton, ActiveBackButton},
+                                    {sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), IdleInstructionsButton, ActiveInstructionsButton}};
 
-    setSprite(sf::Vector2f(0, 0), sf::Vector2f(5, 5), this->gameModeBackgroundTexture, this->backgroundSprite);
-
-    this->onePlayerButton = new Button(sf::Vector2f(88 * 5, 92 * 5), sf::Vector2f(5, 5), this->idleOnePlayerButtonTexture, this->activeOnePlayerButtonTexture);
-    this->twoPlayerButton = new Button(sf::Vector2f(200 * 5, 92 * 5), sf::Vector2f(5, 5), this->idleTwoPlayerButtonTexture, this->activeTwoPlayerButtonTexture);
-    this->backButton = new Button(sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), this->idleBackButtonTexture, this->activeBackButtonTexture);
-    this->instructionsButton = new Button(sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), this->idleInstructionsButtonTexture, this->activeInstructionsButtonTexture);
+    this->resources = ScreenResourceManager(texturePaths, sprites, buttons);
 }
 
 void GameModeSelection::update() {
     sf::Vector2f mousePosition = State::getMousePosition();
-    this->onePlayerButton->updateButtonState(mousePosition);
-    this->twoPlayerButton->updateButtonState(mousePosition);
-    this->backButton->updateButtonState(mousePosition);
-    this->instructionsButton->updateButtonState(mousePosition);
+
+    resources.getButton(OnePlayer).updateButtonState(mousePosition);
+    resources.getButton(TwoPlayers).updateButtonState(mousePosition);
+    resources.getButton(Back).updateButtonState(mousePosition);
+    resources.getButton(Instructions).updateButtonState(mousePosition);
 }
 
 void GameModeSelection::poll() {
@@ -48,18 +43,18 @@ void GameModeSelection::poll() {
                 break;
             case sf::Event::MouseButtonReleased:
                 if (event.mouseButton.button == sf::Mouse::Left) {
-                    if (this->onePlayerButton->getButtonState()) {
+                    if (resources.getButton(OnePlayer).getButtonState()) {
                         State::gameMode = State::GameMode::SINGLE_PLAYER;
                         State::changeScreen(Screens::DIFFICULTY_SELECTION);
                         break;
-                    } else if (this->twoPlayerButton->getButtonState()) {
+                    } else if (resources.getButton(TwoPlayers).getButtonState()) {
                         State::gameMode = State::GameMode::MULTI_PLAYER;
                         State::changeScreen(Screens::FLEET_PLACEMENT);
                         break;
-                    } else if (this->backButton->getButtonState()) {
+                    } else if (resources.getButton(Back).getButtonState()) {
                         State::previousScreen();
                         break;
-                    } else if (this->instructionsButton->getButtonState()) {
+                    } else if (resources.getButton(Instructions).getButtonState()) {
                         State::changeScreen(Screens::INSTRUCTIONS);
                         break;
                     } else {
@@ -76,11 +71,11 @@ void GameModeSelection::render() {
     sf::RenderWindow &gui = *State::gui;
     gui.clear();
 
-    gui.draw(this->backgroundSprite);
-    onePlayerButton->render(gui);
-    twoPlayerButton->render(gui);
-    backButton->render(gui);
-    instructionsButton->render(gui);
+    gui.draw(resources.getSprite(Background));
+    resources.getButton(OnePlayer).render(gui);
+    resources.getButton(TwoPlayers).render(gui);
+    resources.getButton(Back).render(gui);
+    resources.getButton(Instructions).render(gui);
 
     if (State::getCurrentScreen() == Screens::GAME_MODE_SELECTION) {
         gui.display();
@@ -89,7 +84,7 @@ void GameModeSelection::render() {
 
 GameModeSelection &screen::GameModeSelection::getInstance() {
     if (instance == nullptr) {
-        instance = new GameModeSelection();
+        instance.reset(new GameModeSelection());
     }
     return *instance;
 }

--- a/src/screens/gameModeSelection.hpp
+++ b/src/screens/gameModeSelection.hpp
@@ -126,10 +126,6 @@ namespace screen {
          */
         GameModeSelection &operator=(const GameModeSelection &source) = delete;
 
-        /**
-         * Overridden run method of screenTemplate
-         */
-        void run() override;
     };
 }// namespace screen
 

--- a/src/screens/gameModeSelection.hpp
+++ b/src/screens/gameModeSelection.hpp
@@ -125,7 +125,6 @@ namespace screen {
          * Overloaded assignment operator
          */
         GameModeSelection &operator=(const GameModeSelection &source) = delete;
-
     };
 }// namespace screen
 

--- a/src/screens/gameModeSelection.hpp
+++ b/src/screens/gameModeSelection.hpp
@@ -1,6 +1,5 @@
 /**
- * File: gameModeSelection.h
- * Description: Front-end class that defines the behaviour of the Game Mode selection screens
+ * Front-end class that defines the behaviour of the Game Mode selection screens
  */
 
 #ifndef BATTLESHIP_GAMEMODESELECTION_H
@@ -14,102 +13,6 @@ using entity::Button;
 
 namespace screen {
     class GameModeSelection : public ScreenTemplate {
-    private:
-        /**
-         * Background texture
-         */
-        sf::Texture gameModeBackgroundTexture;
-
-        /**
-         * Idle 1 player button texture
-         */
-        sf::Texture idleOnePlayerButtonTexture;
-
-        /**
-         * Active 1 player button texture
-         */
-        sf::Texture activeOnePlayerButtonTexture;
-
-        /**
-         * Idle 2 player button texture
-         */
-        sf::Texture idleTwoPlayerButtonTexture;
-
-        /**
-         * Active 2 player button texture
-         */
-        sf::Texture activeTwoPlayerButtonTexture;
-
-        /**
-         * Idle back button texture
-         */
-        sf::Texture idleBackButtonTexture;
-
-        /**
-         * Active back button texture
-         */
-        sf::Texture activeBackButtonTexture;
-
-        /**
-         * Idle instructions button texture
-         */
-        sf::Texture idleInstructionsButtonTexture;
-
-        /**
-         * Active instructions button texture
-         */
-        sf::Texture activeInstructionsButtonTexture;
-
-        /**
-         * Background sprite
-         */
-        sf::Sprite backgroundSprite;
-
-        /**
-         * 1 Player button
-         */
-        Button *onePlayerButton;
-
-        /**
-         * 2 Player button
-         */
-        Button *twoPlayerButton;
-
-        /**
-         * Back button
-         */
-        Button *backButton;
-
-        /**
-         * Instructions button
-         */
-        Button *instructionsButton;
-
-        /**
-         * Updates the buttons on this screen
-         */
-        void update();
-
-        /**
-         * Polls for system events
-         */
-        void poll();
-
-        /**
-         * Renders all sprites
-         */
-        void render();
-
-        /**
-         * Constructor
-         */
-        GameModeSelection();
-
-        /**
-         *
-         */
-        static GameModeSelection *instance;
-
     public:
         /**
          *
@@ -125,6 +28,40 @@ namespace screen {
          * Overloaded assignment operator
          */
         GameModeSelection &operator=(const GameModeSelection &source) = delete;
+
+    private:
+        // Singleton instance
+        static std::unique_ptr<GameModeSelection> instance;
+
+        // Singleton constructor
+        GameModeSelection();
+
+        // SFML event loop helpers
+        void update() override;
+        void poll() override;
+        void render() override;
+
+        // Names to refer to resources on this screen
+        enum textureNames {
+            Background_,
+            IdleOnePlayer,
+            ActiveOnePlayer,
+            IdleTwoPlayer,
+            ActiveTwoPlayer,
+            IdleBackButton,
+            ActiveBackButton,
+            IdleInstructionsButton,
+            ActiveInstructionsButton
+        };
+        enum spriteNames {
+            Background
+        };
+        enum buttonNames {
+            OnePlayer,
+            TwoPlayers,
+            Back,
+            Instructions
+        };
     };
 }// namespace screen
 

--- a/src/screens/gameOver.cpp
+++ b/src/screens/gameOver.cpp
@@ -19,18 +19,6 @@ GameOver::GameOver() : ScreenTemplate() {
     const vector<button> buttons = {{sf::Vector2f(136 * 5, 108 * 5), sf::Vector2f(5, 5),
                                      textureNames::IdleHomepageButton, textureNames::ActiveHomepageButton}};
     this->resources = ScreenResourceManager(texturePaths, sprites, buttons);
-
-    loadTexture(this->gameOverWinBackgroundTexture, "gameOver/GameOverWinBackground.png");
-    loadTexture(this->gameOverLoseBackgroundTexture, "gameOver/GameOverLoseBackground.png");
-    loadTexture(this->gameOverP1BackgroundTexture, "gameOver/GameOverP1Background.png");
-    loadTexture(this->gameOverP2BackgroundTexture, "gameOver/GameOverP2Background.png");
-    loadTexture(this->idleHomepageButtonTexture, "gameOver/IdleHomepageButton.png");
-    loadTexture(this->activeHomepageButtonTexture, "gameOver/ActiveHomepageButton.png");
-
-    setSprite(sf::Vector2f(0, 0), sf::Vector2f(5, 5), this->gameOverWinBackgroundTexture, this->backgroundWinSprite);
-    setSprite(sf::Vector2f(0, 0), sf::Vector2f(5, 5), this->gameOverLoseBackgroundTexture, this->backgroundLoseSprite);
-    setSprite(sf::Vector2f(0, 0), sf::Vector2f(5, 5), this->gameOverP1BackgroundTexture, this->backgroundP1Sprite);
-    setSprite(sf::Vector2f(0, 0), sf::Vector2f(5, 5), this->gameOverP2BackgroundTexture, this->backgroundP2Sprite);
 }
 
 void GameOver::update() {
@@ -66,15 +54,15 @@ void GameOver::render() {
     gui.clear();
     if (State::gameMode == State::GameMode::SINGLE_PLAYER) {
         if (State::player == State::Player::P1) {
-            gui.draw(this->backgroundLoseSprite);
+            gui.draw(resources.getSprite(spriteNames::BackgroundLose));
         } else {
-            gui.draw(this->backgroundWinSprite);
+            gui.draw(resources.getSprite(spriteNames::BackgroundWin));
         }
     } else {
         if (State::player == State::Player::P1) {
-            gui.draw(this->backgroundP2Sprite);
+            gui.draw(resources.getSprite(spriteNames::BackgroundP2));
         } else {
-            gui.draw(this->backgroundP1Sprite);
+            gui.draw(resources.getSprite(spriteNames::BackgroundP1));
         }
     }
 

--- a/src/screens/gameOver.cpp
+++ b/src/screens/gameOver.cpp
@@ -80,12 +80,6 @@ void GameOver::render() {
     }
 }
 
-void GameOver::run() {
-    this->update();
-    this->poll();
-    this->render();
-}
-
 GameOver& screen::GameOver::getInstance() {
     if (instance == nullptr) {
         instance = new GameOver();

--- a/src/screens/gameOver.cpp
+++ b/src/screens/gameOver.cpp
@@ -10,6 +10,12 @@ using screen::GameOver;
 std::unique_ptr<GameOver> GameOver::instance = nullptr;
 
 GameOver::GameOver() : ScreenTemplate() {
+    const vector<string> texturePaths = {"homepage/HomepageBackground.png",
+                                      "homepage/IdlePlayButton.png", "homepage/ActivePlayButton.png"};
+    const vector<sprite> sprites = {};
+    const vector<button> buttons = {};
+    this->resources = ScreenResourceManager(texturePaths, sprites, buttons);
+
     loadTexture(this->gameOverWinBackgroundTexture, "gameOver/GameOverWinBackground.png");
     loadTexture(this->gameOverLoseBackgroundTexture, "gameOver/GameOverLoseBackground.png");
     loadTexture(this->gameOverP1BackgroundTexture, "gameOver/GameOverP1Background.png");

--- a/src/screens/gameOver.cpp
+++ b/src/screens/gameOver.cpp
@@ -31,13 +31,11 @@ GameOver::GameOver() : ScreenTemplate() {
     setSprite(sf::Vector2f(0, 0), sf::Vector2f(5, 5), this->gameOverLoseBackgroundTexture, this->backgroundLoseSprite);
     setSprite(sf::Vector2f(0, 0), sf::Vector2f(5, 5), this->gameOverP1BackgroundTexture, this->backgroundP1Sprite);
     setSprite(sf::Vector2f(0, 0), sf::Vector2f(5, 5), this->gameOverP2BackgroundTexture, this->backgroundP2Sprite);
-
-    this->homepageButton = new Button(sf::Vector2f(136 * 5, 108 * 5), sf::Vector2f(5, 5), this->idleHomepageButtonTexture, this->activeHomepageButtonTexture);
 }
 
 void GameOver::update() {
     sf::Vector2f mousePosition = State::getMousePosition();
-    this->homepageButton->updateButtonState(mousePosition);
+    resources.getButton(buttonNames::Homepage).updateButtonState(mousePosition);
 }
 
 void GameOver::poll() {
@@ -46,19 +44,16 @@ void GameOver::poll() {
 
     while (gui.pollEvent(event)) {
         switch (event.type) {
-
             case sf::Event::Closed:
                 gui.close();
                 break;
-
             case sf::Event::MouseButtonReleased:
-                if ((event.mouseButton.button == sf::Mouse::Left) && (this->homepageButton->getButtonState())) {
+                if (event.mouseButton.button == sf::Mouse::Left && resources.getButton(buttonNames::Homepage).getButtonState()) {
                     State::changeScreen(Screens::HOMEPAGE);
                     break;
                 } else {
                     break;
                 }
-
             default:
                 break;
         }
@@ -83,7 +78,7 @@ void GameOver::render() {
         }
     }
 
-    homepageButton->render(gui);
+    resources.getButton(buttonNames::Homepage).render(gui);
 
     if (State::getCurrentScreen() == Screens::GAME_OVER) {
         gui.display();

--- a/src/screens/gameOver.cpp
+++ b/src/screens/gameOver.cpp
@@ -3,17 +3,21 @@
  */
 
 #include "gameOver.hpp"
-#include "../helpers/helperFunctions.hpp"
 
 using screen::GameOver;
 
 std::unique_ptr<GameOver> GameOver::instance = nullptr;
 
 GameOver::GameOver() : ScreenTemplate() {
-    const vector<string> texturePaths = {"homepage/HomepageBackground.png",
-                                      "homepage/IdlePlayButton.png", "homepage/ActivePlayButton.png"};
-    const vector<sprite> sprites = {};
-    const vector<button> buttons = {};
+    const vector<string> texturePaths = {"gameOver/GameOverWinBackground.png", "gameOver/GameOverLoseBackground.png",
+                                         "gameOver/GameOverP1Background.png", "gameOver/GameOverP2Background.png",
+                                         "gameOver/IdleHomepageButton.png", "gameOver/ActiveHomepageButton.png"};
+    const vector<sprite> sprites = {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::GameOverWinBackground},
+                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::GameOverLoseBackground},
+                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::GameOverP1Background},
+                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::GameOverP2Background}};
+    const vector<button> buttons = {{sf::Vector2f(136 * 5, 108 * 5), sf::Vector2f(5, 5),
+                                     textureNames::IdleHomepageButton, textureNames::ActiveHomepageButton}};
     this->resources = ScreenResourceManager(texturePaths, sprites, buttons);
 
     loadTexture(this->gameOverWinBackgroundTexture, "gameOver/GameOverWinBackground.png");

--- a/src/screens/gameOver.cpp
+++ b/src/screens/gameOver.cpp
@@ -8,6 +8,13 @@ using screen::GameOver;
 
 std::unique_ptr<GameOver> GameOver::instance = nullptr;
 
+GameOver &screen::GameOver::getInstance() {
+    if (instance == nullptr) {
+        instance.reset(new GameOver());
+    }
+    return *instance;
+}
+
 GameOver::GameOver() : ScreenTemplate() {
     const vector<string> texturePaths = {"gameOver/GameOverWinBackground.png", "gameOver/GameOverLoseBackground.png",
                                          "gameOver/GameOverP1Background.png", "gameOver/GameOverP2Background.png",
@@ -38,10 +45,8 @@ void GameOver::poll() {
             case sf::Event::MouseButtonReleased:
                 if (event.mouseButton.button == sf::Mouse::Left && resources.getButton(buttonNames::Homepage).getButtonState()) {
                     State::changeScreen(Screens::HOMEPAGE);
-                    break;
-                } else {
-                    break;
                 }
+                break;
             default:
                 break;
         }
@@ -52,30 +57,17 @@ void GameOver::render() {
     sf::RenderWindow &gui = *State::gui;
 
     gui.clear();
+    sf::Sprite background;
     if (State::gameMode == State::GameMode::SINGLE_PLAYER) {
-        if (State::player == State::Player::P1) {
-            gui.draw(resources.getSprite(spriteNames::BackgroundLose));
-        } else {
-            gui.draw(resources.getSprite(spriteNames::BackgroundWin));
-        }
+        background = State::player == State::Player::P1 ? resources.getSprite(spriteNames::BackgroundLose) : resources.getSprite(spriteNames::BackgroundWin);
     } else {
-        if (State::player == State::Player::P1) {
-            gui.draw(resources.getSprite(spriteNames::BackgroundP2));
-        } else {
-            gui.draw(resources.getSprite(spriteNames::BackgroundP1));
-        }
+        background = State::player == State::Player::P1 ? resources.getSprite(spriteNames::BackgroundP2) : resources.getSprite(spriteNames::BackgroundP1);
     }
+    gui.draw(background);
 
     resources.getButton(buttonNames::Homepage).render(gui);
 
     if (State::getCurrentScreen() == Screens::GAME_OVER) {
         gui.display();
     }
-}
-
-GameOver &screen::GameOver::getInstance() {
-    if (instance == nullptr) {
-        instance.reset(new GameOver());
-    }
-    return *instance;
 }

--- a/src/screens/gameOver.cpp
+++ b/src/screens/gameOver.cpp
@@ -80,7 +80,7 @@ void GameOver::render() {
     }
 }
 
-GameOver& screen::GameOver::getInstance() {
+GameOver &screen::GameOver::getInstance() {
     if (instance == nullptr) {
         instance = new GameOver();
     }

--- a/src/screens/gameOver.cpp
+++ b/src/screens/gameOver.cpp
@@ -7,7 +7,7 @@
 
 using screen::GameOver;
 
-GameOver *GameOver::instance = nullptr;
+std::unique_ptr<GameOver> GameOver::instance = nullptr;
 
 GameOver::GameOver() : ScreenTemplate() {
     loadTexture(this->gameOverWinBackgroundTexture, "gameOver/GameOverWinBackground.png");
@@ -82,7 +82,7 @@ void GameOver::render() {
 
 GameOver &screen::GameOver::getInstance() {
     if (instance == nullptr) {
-        instance = new GameOver();
+        instance.reset(new GameOver());
     }
     return *instance;
 }

--- a/src/screens/gameOver.hpp
+++ b/src/screens/gameOver.hpp
@@ -5,8 +5,8 @@
 #ifndef BATTLESHIP_GAMEOVER_H
 #define BATTLESHIP_GAMEOVER_H
 
-#include "../entity/button.hpp"
 #include "../controllers/screenTemplate.hpp"
+#include "../entity/button.hpp"
 #include <SFML/System.hpp>
 
 using entity::Button;
@@ -109,8 +109,7 @@ namespace screen {
          * Overloaded assignment operator
          */
         GameOver &operator=(const GameOver &source) = delete;
-
     };
-}// namespace screens
+}// namespace screen
 
 #endif// BATTLESHIP_GAMEOVER_H

--- a/src/screens/gameOver.hpp
+++ b/src/screens/gameOver.hpp
@@ -30,20 +30,6 @@ namespace screen {
         GameOver &operator=(const GameOver &source) = delete;
 
     private:
-        sf::Texture gameOverWinBackgroundTexture;
-        sf::Texture gameOverLoseBackgroundTexture;
-        sf::Texture gameOverP1BackgroundTexture;
-        sf::Texture gameOverP2BackgroundTexture;
-        sf::Texture idleHomepageButtonTexture;
-        sf::Texture activeHomepageButtonTexture;
-
-        sf::Sprite backgroundWinSprite;
-        sf::Sprite backgroundLoseSprite;
-        sf::Sprite backgroundP1Sprite;
-        sf::Sprite backgroundP2Sprite;
-
-        Button *homepageButton;
-
         // Singleton instance
         static std::unique_ptr<GameOver> instance;
 

--- a/src/screens/gameOver.hpp
+++ b/src/screens/gameOver.hpp
@@ -13,87 +13,6 @@ using entity::Button;
 
 namespace screen {
     class GameOver : public ScreenTemplate {
-    private:
-        /**
-         * Win background texture
-         */
-        sf::Texture gameOverWinBackgroundTexture;
-
-        /**
-         * Lose background texture
-         */
-        sf::Texture gameOverLoseBackgroundTexture;
-
-        /**
-         * P1 background texture
-         */
-        sf::Texture gameOverP1BackgroundTexture;
-
-        /**
-         * P2 background texture
-         */
-        sf::Texture gameOverP2BackgroundTexture;
-
-        /**
-         * Idle homepage button texture
-         */
-        sf::Texture idleHomepageButtonTexture;
-
-        /**
-         * Active continue button texture
-         */
-        sf::Texture activeHomepageButtonTexture;
-
-        /**
-         * Backgroud win sprite
-         */
-        sf::Sprite backgroundWinSprite;
-
-        /**
-         * Backgroud lose sprite
-         */
-        sf::Sprite backgroundLoseSprite;
-
-        /**
-         * Backgroud P1 sprite
-         */
-        sf::Sprite backgroundP1Sprite;
-
-        /**
-         * Backgroud P2 sprite
-         */
-        sf::Sprite backgroundP2Sprite;
-
-        /**
-         * Homepage button 
-         */
-        Button *homepageButton;
-
-        /**
-         * Calls helpers::updateMousePosition() and entity::Button::updateButtonState()
-         */
-        void update();
-
-        /**
-         * Polls for system events
-         */
-        void poll();
-
-        /**
-         * Renders all sprites
-         */
-        void render();
-
-        /**
-         * Constructor
-         */
-        GameOver();
-
-        /**
-         *
-         */
-        static GameOver *instance;
-
     public:
         /**
          *
@@ -109,6 +28,51 @@ namespace screen {
          * Overloaded assignment operator
          */
         GameOver &operator=(const GameOver &source) = delete;
+
+    private:
+        sf::Texture gameOverWinBackgroundTexture;
+        sf::Texture gameOverLoseBackgroundTexture;
+        sf::Texture gameOverP1BackgroundTexture;
+        sf::Texture gameOverP2BackgroundTexture;
+        sf::Texture idleHomepageButtonTexture;
+        sf::Texture activeHomepageButtonTexture;
+
+        sf::Sprite backgroundWinSprite;
+        sf::Sprite backgroundLoseSprite;
+        sf::Sprite backgroundP1Sprite;
+        sf::Sprite backgroundP2Sprite;
+
+        Button *homepageButton;
+
+        // Singleton instance
+        static std::unique_ptr<GameOver> instance;
+
+        // Singleton constructor
+        GameOver();
+
+        // SFML event loop helpers
+        void update() override;
+        void poll() override;
+        void render() override;
+
+        // Names to refer to resources on this screen
+        enum textureNames {
+            GameOverWinBackground,
+            GameOverLoseBackground,
+            GameOverP1Background,
+            GameOverP2Background,
+            IdleHomepageButton,
+            ActiveHomepageButton
+        };
+        enum spriteNames {
+            BackgroundWin,
+            BackgroundLose,
+            BackgroundP1,
+            BackgroundP2
+        };
+        enum buttonNames {
+            Homepage
+        };
     };
 }// namespace screen
 

--- a/src/screens/gameOver.hpp
+++ b/src/screens/gameOver.hpp
@@ -110,10 +110,6 @@ namespace screen {
          */
         GameOver &operator=(const GameOver &source) = delete;
 
-        /**
-         * Overridden run method of screenTemplate
-         */
-        void run() override;
     };
 }// namespace screens
 

--- a/src/screens/gameplay.cpp
+++ b/src/screens/gameplay.cpp
@@ -543,12 +543,6 @@ void Gameplay::render() {
     }
 }
 
-void Gameplay::run() {
-    this->update();
-    this->poll();
-    this->render();
-}
-
 void screen::Gameplay::sleepMS() {
 #ifdef _WIN32
     Sleep(sleepTimeMS);

--- a/src/screens/gameplay.cpp
+++ b/src/screens/gameplay.cpp
@@ -21,7 +21,7 @@ Grid *Gameplay::gridP2 = new Grid();
 map<shipNames, tuple<Coordinate, bool>> Gameplay::fleetLayoutP1 = *new map<shipNames, tuple<Coordinate, bool>>;
 map<shipNames, tuple<Coordinate, bool>> Gameplay::fleetLayoutP2 = *new map<shipNames, tuple<Coordinate, bool>>;
 
-Gameplay *Gameplay::instance = nullptr;
+std::unique_ptr<Gameplay> Gameplay::instance = nullptr;
 
 Gameplay::Gameplay() : ScreenTemplate() {
     loadTexture(this->gameplayDefaultBackgroundTexture, "gameplay/GameplayBackground.png");
@@ -553,7 +553,7 @@ void screen::Gameplay::sleepMS() {
 
 Gameplay &screen::Gameplay::getInstance() {
     if (instance == nullptr) {
-        instance = new Gameplay;
+        instance.reset(new Gameplay);
     }
     return *instance;
 }

--- a/src/screens/gameplay.cpp
+++ b/src/screens/gameplay.cpp
@@ -20,12 +20,27 @@ using std::get;
 std::unique_ptr<Gameplay> Gameplay::instance = nullptr;
 
 Gameplay::Gameplay() : ScreenTemplate() {
-    //
     gridP1 = std::make_unique<Grid>();
     gridP2 = std::make_unique<Grid>();
 
     fleetLayoutP1 = std::make_unique<shipOrientations>();
     fleetLayoutP2 = std::make_unique<shipOrientations>();
+
+    const vector<string> texturePaths = {"gameplay/GameplayBackground.png", "gameplay/GameplayP1Background.png",
+                                         "gameplay/GameplayP2Background.png",
+                                         "gameplay/IdleSurrenderButton.png", "gameplay/ActiveSurrenderButton.png",
+                                         "gameplay/IdleInstructionsButton.png", "gameplay/ActiveInstructionsButton.png",
+                                         "gameplay/BattleShip.png", "gameplay/AircraftCarrier.png", "gameplay/Destroyer.png",
+                                         "gameplay/Submarine.png", "gameplay/PatrolBoat.png", "gameplay/RowBoat.png",
+                                         "gameplay/BattleShipSunk.png", "gameplay/AircraftCarrierSunk.png", "gameplay/DestroyerSunk.png",
+                                         "gameplay/SubmarineSunk.png", "gameplay/PatrolBoatSunk.png", "gameplay/RowBoatSunk.png",
+                                         "gameplay/PrimaryHitMarker.png", "gameplay/PrimaryMissMarker.png",
+                                         "gameplay/SecondaryHitMarker.png", "gameplay/SecondaryMissMarker.png",
+                                         "gameplay/SecondaryTarget.png"};
+    const vector<sprite> sprites = {};
+    const vector<button> buttons = {};
+
+    this->resources = ScreenResourceManager(texturePaths, sprites, buttons);
 
     loadTexture(this->gameplayDefaultBackgroundTexture, "gameplay/GameplayBackground.png");
     loadTexture(this->gameplayP1BackgroundTexture, "gameplay/GameplayP1Background.png");

--- a/src/screens/gameplay.cpp
+++ b/src/screens/gameplay.cpp
@@ -37,26 +37,30 @@ Gameplay::Gameplay() : ScreenTemplate() {
                                          "gameplay/PrimaryHitMarker.png", "gameplay/PrimaryMissMarker.png",
                                          "gameplay/SecondaryHitMarker.png", "gameplay/SecondaryMissMarker.png",
                                          "gameplay/SecondaryTarget.png"};
+
     const vector<sprite> sprites = {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), BackgroundDefault_},
                                     {sf::Vector2f(0, 0), sf::Vector2f(5, 5), BackgroundP1},
                                     {sf::Vector2f(0, 0), sf::Vector2f(5, 5), BackgroundP2},
-                                    {sf::Vector2f(330 * 5, 113 * 5), sf::Vector2f(5, 5), BattleShipSunk_},
+
+                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), Battleship_},
+                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), AircraftCarrier_},
+                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), Destroyer_},
+                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), Submarine_},
+                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), PatrolBoat_},
+                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), RowBoat_},
+
+                                    {sf::Vector2f(330 * 5, 113 * 5), sf::Vector2f(5, 5), BattleshipSunk_},
                                     {sf::Vector2f(348 * 5, 117 * 5), sf::Vector2f(5, 5), AircraftCarrierSunk_},
                                     {sf::Vector2f(348 * 5, 75 * 5), sf::Vector2f(5, 5), DestroyerSunk_},
                                     {sf::Vector2f(330 * 5, 79 * 5), sf::Vector2f(5, 5), SubmarineSunk_},
                                     {sf::Vector2f(330 * 5, 53 * 5), sf::Vector2f(5, 5), PatrolBoatSunk_},
                                     {sf::Vector2f(348 * 5, 57 * 5), sf::Vector2f(5, 5), RowBoatSunk_}};
+
     const vector<button> buttons = {{sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), IdleSurrenderButton, ActiveSurrenderButton},
                                     {sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), IdleInstructionsButton, ActiveInstructionsButton}};
 
     this->resources = ScreenResourceManager(texturePaths, sprites, buttons);
 
-    loadTexture(this->battleshipTexture, "gameplay/Battleship.png");
-    loadTexture(this->aircraftCarrierTexture, "gameplay/AircraftCarrier.png");
-    loadTexture(this->destroyerTexture, "gameplay/Destroyer.png");
-    loadTexture(this->submarineTexture, "gameplay/Submarine.png");
-    loadTexture(this->patrolBoatTexture, "gameplay/PatrolBoat.png");
-    loadTexture(this->rowBoatTexture, "gameplay/RowBoat.png");
 
     loadTexture(this->primaryHitMarkerTexture, "gameplay/PrimaryHitMarker.png");
     loadTexture(this->primaryMissMarkerTexture, "gameplay/PrimaryMissMarker.png");
@@ -65,19 +69,6 @@ Gameplay::Gameplay() : ScreenTemplate() {
 
     Target::initializeTextures();
     loadTexture(this->secondaryTargetTexture, "gameplay/SecondaryTarget.png");
-
-    this->battleshipSprite.setTexture(this->battleshipTexture);
-    this->battleshipSprite.setScale(sf::Vector2f(5, 5));
-    this->aircraftCarrierSprite.setTexture(this->aircraftCarrierTexture);
-    this->aircraftCarrierSprite.setScale(sf::Vector2f(5, 5));
-    this->destroyerSprite.setTexture(this->destroyerTexture);
-    this->destroyerSprite.setScale(sf::Vector2f(5, 5));
-    this->submarineSprite.setTexture(this->submarineTexture);
-    this->submarineSprite.setScale(sf::Vector2f(5, 5));
-    this->patrolBoatSprite.setTexture(this->patrolBoatTexture);
-    this->patrolBoatSprite.setScale(sf::Vector2f(5, 5));
-    this->rowBoatSprite.setTexture(this->rowBoatTexture);
-    this->rowBoatSprite.setScale(sf::Vector2f(5, 5));
 
     this->primaryHitMarkerSprite.setTexture(this->primaryHitMarkerTexture);
     this->primaryHitMarkerSprite.setScale(sf::Vector2f(5, 5));
@@ -299,64 +290,71 @@ void Gameplay::updateGrid(Coordinate &coordinate, sf::RenderWindow &gui) {
 }
 
 void Gameplay::setFleetLayout(shipOrientations &fleetLayout) {
+    sf::Sprite &battleship = resources.getSprite(Battleship);
+    sf::Sprite &aircraftCarrier = resources.getSprite(AircraftCarrier);
+    sf::Sprite &destroyer = resources.getSprite(Destroyer);
+    sf::Sprite &submarine = resources.getSprite(Submarine);
+    sf::Sprite &patrolBoat = resources.getSprite(PatrolBoat);
+    sf::Sprite &rowBoat = resources.getSprite(RowBoat);
+
     if (get<1>(fleetLayout[shipNames::BATTLESHIP]) == 1) {
-        this->battleshipSprite.setPosition(sf::Vector2f((64 + (get<0>(fleetLayout[shipNames::BATTLESHIP]).getX() * 8)) * 5,
-                                                        (44 + (get<0>(fleetLayout[shipNames::BATTLESHIP]).getY() * 8)) * 5));
-        this->battleshipSprite.setRotation(90.f);
+        battleship.setPosition(sf::Vector2f((64 + (get<0>(fleetLayout[shipNames::BATTLESHIP]).getX() * 8)) * 5,
+                                            (44 + (get<0>(fleetLayout[shipNames::BATTLESHIP]).getY() * 8)) * 5));
+        battleship.setRotation(90.f);
     } else {
-        this->battleshipSprite.setPosition(sf::Vector2f((16 + (get<0>(fleetLayout[shipNames::BATTLESHIP]).getX() * 8)) * 5,
-                                                        (44 + (get<0>(fleetLayout[shipNames::BATTLESHIP]).getY() * 8)) * 5));
-        this->battleshipSprite.setRotation(0);
+        battleship.setPosition(sf::Vector2f((16 + (get<0>(fleetLayout[shipNames::BATTLESHIP]).getX() * 8)) * 5,
+                                            (44 + (get<0>(fleetLayout[shipNames::BATTLESHIP]).getY() * 8)) * 5));
+        battleship.setRotation(0);
     }
 
     if (get<1>(fleetLayout[shipNames::AIRCRAFT_CARRIER]) == 1) {
-        this->aircraftCarrierSprite.setPosition(sf::Vector2f((56 + (get<0>(fleetLayout[shipNames::AIRCRAFT_CARRIER]).getX() * 8)) * 5,
-                                                             (44 + (get<0>(fleetLayout[shipNames::AIRCRAFT_CARRIER]).getY() * 8)) * 5));
-        this->aircraftCarrierSprite.setRotation(90.f);
+        aircraftCarrier.setPosition(sf::Vector2f((56 + (get<0>(fleetLayout[shipNames::AIRCRAFT_CARRIER]).getX() * 8)) * 5,
+                                                 (44 + (get<0>(fleetLayout[shipNames::AIRCRAFT_CARRIER]).getY() * 8)) * 5));
+        aircraftCarrier.setRotation(90.f);
     } else {
-        this->aircraftCarrierSprite.setPosition(sf::Vector2f((16 + (get<0>(fleetLayout[shipNames::AIRCRAFT_CARRIER]).getX() * 8)) * 5,
-                                                             (44 + (get<0>(fleetLayout[shipNames::AIRCRAFT_CARRIER]).getY() * 8)) * 5));
-        this->aircraftCarrierSprite.setRotation(0);
+        aircraftCarrier.setPosition(sf::Vector2f((16 + (get<0>(fleetLayout[shipNames::AIRCRAFT_CARRIER]).getX() * 8)) * 5,
+                                                 (44 + (get<0>(fleetLayout[shipNames::AIRCRAFT_CARRIER]).getY() * 8)) * 5));
+        aircraftCarrier.setRotation(0);
     }
 
     if (get<1>(fleetLayout[shipNames::DESTROYER]) == 1) {
-        this->destroyerSprite.setPosition(sf::Vector2f((48 + (get<0>(fleetLayout[shipNames::DESTROYER]).getX() * 8)) * 5,
-                                                       (44 + (get<0>(fleetLayout[shipNames::DESTROYER]).getY() * 8)) * 5));
-        this->destroyerSprite.setRotation(90.f);
+        destroyer.setPosition(sf::Vector2f((48 + (get<0>(fleetLayout[shipNames::DESTROYER]).getX() * 8)) * 5,
+                                           (44 + (get<0>(fleetLayout[shipNames::DESTROYER]).getY() * 8)) * 5));
+        destroyer.setRotation(90.f);
     } else {
-        this->destroyerSprite.setPosition(sf::Vector2f((16 + (get<0>(fleetLayout[shipNames::DESTROYER]).getX() * 8)) * 5,
-                                                       (44 + (get<0>(fleetLayout[shipNames::DESTROYER]).getY() * 8)) * 5));
-        this->destroyerSprite.setRotation(0);
+        destroyer.setPosition(sf::Vector2f((16 + (get<0>(fleetLayout[shipNames::DESTROYER]).getX() * 8)) * 5,
+                                           (44 + (get<0>(fleetLayout[shipNames::DESTROYER]).getY() * 8)) * 5));
+        destroyer.setRotation(0);
     }
 
     if (get<1>(fleetLayout[shipNames::SUBMARINE]) == 1) {
-        this->submarineSprite.setPosition(sf::Vector2f((40 + (get<0>(fleetLayout[shipNames::SUBMARINE]).getX() * 8)) * 5,
-                                                       (44 + (get<0>(fleetLayout[shipNames::SUBMARINE]).getY() * 8)) * 5));
-        this->submarineSprite.setRotation(90.f);
+        submarine.setPosition(sf::Vector2f((40 + (get<0>(fleetLayout[shipNames::SUBMARINE]).getX() * 8)) * 5,
+                                           (44 + (get<0>(fleetLayout[shipNames::SUBMARINE]).getY() * 8)) * 5));
+        submarine.setRotation(90.f);
     } else {
-        this->submarineSprite.setPosition(sf::Vector2f((16 + (get<0>(fleetLayout[shipNames::SUBMARINE]).getX() * 8)) * 5,
-                                                       (44 + (get<0>(fleetLayout[shipNames::SUBMARINE]).getY() * 8)) * 5));
-        this->submarineSprite.setRotation(0);
+        submarine.setPosition(sf::Vector2f((16 + (get<0>(fleetLayout[shipNames::SUBMARINE]).getX() * 8)) * 5,
+                                           (44 + (get<0>(fleetLayout[shipNames::SUBMARINE]).getY() * 8)) * 5));
+        submarine.setRotation(0);
     }
 
     if (get<1>(fleetLayout[shipNames::PATROL_BOAT]) == 1) {
-        this->patrolBoatSprite.setPosition(sf::Vector2f((32 + (get<0>(fleetLayout[shipNames::PATROL_BOAT]).getX() * 8)) * 5,
-                                                        (44 + (get<0>(fleetLayout[shipNames::PATROL_BOAT]).getY() * 8)) * 5));
-        this->patrolBoatSprite.setRotation(90.f);
+        patrolBoat.setPosition(sf::Vector2f((32 + (get<0>(fleetLayout[shipNames::PATROL_BOAT]).getX() * 8)) * 5,
+                                            (44 + (get<0>(fleetLayout[shipNames::PATROL_BOAT]).getY() * 8)) * 5));
+        patrolBoat.setRotation(90.f);
     } else {
-        this->patrolBoatSprite.setPosition(sf::Vector2f((16 + (get<0>(fleetLayout[shipNames::PATROL_BOAT]).getX() * 8)) * 5,
-                                                        (44 + (get<0>(fleetLayout[shipNames::PATROL_BOAT]).getY() * 8)) * 5));
-        this->patrolBoatSprite.setRotation(0);
+        patrolBoat.setPosition(sf::Vector2f((16 + (get<0>(fleetLayout[shipNames::PATROL_BOAT]).getX() * 8)) * 5,
+                                            (44 + (get<0>(fleetLayout[shipNames::PATROL_BOAT]).getY() * 8)) * 5));
+        patrolBoat.setRotation(0);
     }
 
     if (get<1>(fleetLayout[shipNames::ROW_BOAT]) == 1) {
-        this->rowBoatSprite.setPosition(sf::Vector2f((24 + (get<0>(fleetLayout[shipNames::ROW_BOAT]).getX() * 8)) * 5,
-                                                     (44 + (get<0>(fleetLayout[shipNames::ROW_BOAT]).getY() * 8)) * 5));
-        this->rowBoatSprite.setRotation(90.0);
+        rowBoat.setPosition(sf::Vector2f((24 + (get<0>(fleetLayout[shipNames::ROW_BOAT]).getX() * 8)) * 5,
+                                         (44 + (get<0>(fleetLayout[shipNames::ROW_BOAT]).getY() * 8)) * 5));
+        rowBoat.setRotation(90.0);
     } else {
-        this->rowBoatSprite.setPosition(sf::Vector2f((16 + (get<0>(fleetLayout[shipNames::ROW_BOAT]).getX() * 8)) * 5,
-                                                     (44 + (get<0>(fleetLayout[shipNames::ROW_BOAT]).getY() * 8)) * 5));
-        this->rowBoatSprite.setRotation(0);
+        rowBoat.setPosition(sf::Vector2f((16 + (get<0>(fleetLayout[shipNames::ROW_BOAT]).getX() * 8)) * 5,
+                                         (44 + (get<0>(fleetLayout[shipNames::ROW_BOAT]).getY() * 8)) * 5));
+        rowBoat.setRotation(0);
     }
 }
 
@@ -473,12 +471,12 @@ void Gameplay::render() {
     resources.getButton(Surrender).render(gui);
     resources.getButton(Instructions).render(gui);
 
-    gui.draw(this->battleshipSprite);
-    gui.draw(this->aircraftCarrierSprite);
-    gui.draw(this->destroyerSprite);
-    gui.draw(this->submarineSprite);
-    gui.draw(this->patrolBoatSprite);
-    gui.draw(this->rowBoatSprite);
+    gui.draw(resources.getSprite(Battleship));
+    gui.draw(resources.getSprite(AircraftCarrier));
+    gui.draw(resources.getSprite(Destroyer));
+    gui.draw(resources.getSprite(Battleship));
+    gui.draw(resources.getSprite(PatrolBoat));
+    gui.draw(resources.getSprite(RowBoat));
 
     if (State::gameMode == State::SINGLE_PLAYER) {
         for (auto &primaryMarker : this->primaryMarkersP1Vector) {

--- a/src/screens/gameplay.cpp
+++ b/src/screens/gameplay.cpp
@@ -39,8 +39,8 @@ Gameplay::Gameplay() : ScreenTemplate() {
                                          "gameplay/SecondaryTarget.png"};
 
     const vector<sprite> sprites = {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), BackgroundDefault_},
-                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), BackgroundP1},
-                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), BackgroundP2},
+                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), BackgroundP1_},
+                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), BackgroundP2_},
 
                                     {sf::Vector2f(0, 0), sf::Vector2f(5, 5), Battleship_},
                                     {sf::Vector2f(0, 0), sf::Vector2f(5, 5), AircraftCarrier_},

--- a/src/screens/gameplay.cpp
+++ b/src/screens/gameplay.cpp
@@ -39,7 +39,13 @@ Gameplay::Gameplay() : ScreenTemplate() {
                                          "gameplay/SecondaryTarget.png"};
     const vector<sprite> sprites = {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), BackgroundDefault_},
                                     {sf::Vector2f(0, 0), sf::Vector2f(5, 5), BackgroundP1},
-                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), BackgroundP2}};
+                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), BackgroundP2},
+                                    {sf::Vector2f(330 * 5, 113 * 5), sf::Vector2f(5, 5), BattleShipSunk_},
+                                    {sf::Vector2f(348 * 5, 117 * 5), sf::Vector2f(5, 5), AircraftCarrierSunk_},
+                                    {sf::Vector2f(348 * 5, 75 * 5), sf::Vector2f(5, 5), DestroyerSunk_},
+                                    {sf::Vector2f(330 * 5, 79 * 5), sf::Vector2f(5, 5), SubmarineSunk_},
+                                    {sf::Vector2f(330 * 5, 53 * 5), sf::Vector2f(5, 5), PatrolBoatSunk_},
+                                    {sf::Vector2f(348 * 5, 57 * 5), sf::Vector2f(5, 5), RowBoatSunk_}};
     const vector<button> buttons = {{sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), IdleSurrenderButton, ActiveSurrenderButton},
                                     {sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), IdleInstructionsButton, ActiveInstructionsButton}};
 
@@ -52,13 +58,6 @@ Gameplay::Gameplay() : ScreenTemplate() {
     loadTexture(this->patrolBoatTexture, "gameplay/PatrolBoat.png");
     loadTexture(this->rowBoatTexture, "gameplay/RowBoat.png");
 
-    loadTexture(this->battleshipSunkTexture, "gameplay/BattleshipSunk.png");
-    loadTexture(this->aircraftCarrierSunkTexture, "gameplay/AircraftCarrierSunk.png");
-    loadTexture(this->destroyerSunkTexture, "gameplay/DestroyerSunk.png");
-    loadTexture(this->submarineSunkTexture, "gameplay/SubmarineSunk.png");
-    loadTexture(this->patrolBoatSunkTexture, "gameplay/PatrolBoatSunk.png");
-    loadTexture(this->rowBoatSunkTexture, "gameplay/RowBoatSunk.png");
-
     loadTexture(this->primaryHitMarkerTexture, "gameplay/PrimaryHitMarker.png");
     loadTexture(this->primaryMissMarkerTexture, "gameplay/PrimaryMissMarker.png");
     loadTexture(this->secondaryHitMarkerTexture, "gameplay/SecondaryHitMarker.png");
@@ -66,13 +65,6 @@ Gameplay::Gameplay() : ScreenTemplate() {
 
     Target::initializeTextures();
     loadTexture(this->secondaryTargetTexture, "gameplay/SecondaryTarget.png");
-
-    setSprite(sf::Vector2f(330 * 5, 113 * 5), sf::Vector2f(5, 5), this->battleshipSunkTexture, this->battleshipSunkSprite);
-    setSprite(sf::Vector2f(348 * 5, 117 * 5), sf::Vector2f(5, 5), this->aircraftCarrierSunkTexture, this->aircraftCarrierSunkSprite);
-    setSprite(sf::Vector2f(348 * 5, 75 * 5), sf::Vector2f(5, 5), this->destroyerSunkTexture, this->destroyerSunkSprite);
-    setSprite(sf::Vector2f(330 * 5, 79 * 5), sf::Vector2f(5, 5), this->submarineSunkTexture, this->submarineSunkSprite);
-    setSprite(sf::Vector2f(330 * 5, 53 * 5), sf::Vector2f(5, 5), this->patrolBoatSunkTexture, this->patrolBoatSunkSprite);
-    setSprite(sf::Vector2f(348 * 5, 57 * 5), sf::Vector2f(5, 5), this->rowBoatSunkTexture, this->rowBoatSunkSprite);
 
     this->battleshipSprite.setTexture(this->battleshipTexture);
     this->battleshipSprite.setScale(sf::Vector2f(5, 5));
@@ -235,7 +227,6 @@ void Gameplay::updateGrid(Coordinate &coordinate, sf::RenderWindow &gui) {
                     State::player = State::Player::P2;
                 }
             }
-
         } else {
             SquareType attack = this->gridP1->attack(coordinate);
             if (attack == SquareType::WATER) {
@@ -254,8 +245,6 @@ void Gameplay::updateGrid(Coordinate &coordinate, sf::RenderWindow &gui) {
                 }
             }
         }
-
-
     } else {
         if (State::player == State::Player::P1) {
             SquareType attack = this->gridP2->attack(coordinate);
@@ -443,27 +432,27 @@ void Gameplay::renderShipStatus(Grid &grid) {
     map<shipNames, bool> shipStatus = grid.getShipStatus();
 
     if (shipStatus[shipNames::BATTLESHIP]) {
-        gui.draw(this->battleshipSunkSprite);
+        gui.draw(resources.getSprite(BattleShipSunk));
     }
 
     if (shipStatus[shipNames::AIRCRAFT_CARRIER]) {
-        gui.draw(this->aircraftCarrierSunkSprite);
+        gui.draw(resources.getSprite(AircraftCarrierSunk));
     }
 
     if (shipStatus[shipNames::DESTROYER]) {
-        gui.draw(this->destroyerSunkSprite);
+        gui.draw(resources.getSprite(DestroyerSunk));
     }
 
     if (shipStatus[shipNames::SUBMARINE]) {
-        gui.draw(this->submarineSunkSprite);
+        gui.draw(resources.getSprite(SubmarineSunk));
     }
 
     if (shipStatus[shipNames::PATROL_BOAT]) {
-        gui.draw(this->patrolBoatSunkSprite);
+        gui.draw(resources.getSprite(PatrolBoatSunk));
     }
 
     if (shipStatus[shipNames::ROW_BOAT]) {
-        gui.draw(this->rowBoatSunkSprite);
+        gui.draw(resources.getSprite(RowBoatSunk));
     }
 }
 

--- a/src/screens/gameplay.cpp
+++ b/src/screens/gameplay.cpp
@@ -30,27 +30,31 @@ Gameplay::Gameplay() : ScreenTemplate() {
             "gameplay/GameplayBackground.png",
             "gameplay/GameplayP1Background.png",
             "gameplay/GameplayP2Background.png",
-            "gameplay/IdleSurrenderButton.png",
-            "gameplay/ActiveSurrenderButton.png",
-            "gameplay/IdleInstructionsButton.png",
-            "gameplay/ActiveInstructionsButton.png",
+
             "gameplay/Battleship.png",
             "gameplay/AircraftCarrier.png",
             "gameplay/Destroyer.png",
             "gameplay/Submarine.png",
             "gameplay/PatrolBoat.png",
             "gameplay/RowBoat.png",
+
             "gameplay/BattleshipSunk.png",
             "gameplay/AircraftCarrierSunk.png",
             "gameplay/DestroyerSunk.png",
             "gameplay/SubmarineSunk.png",
             "gameplay/PatrolBoatSunk.png",
             "gameplay/RowBoatSunk.png",
+
             "gameplay/PrimaryHitMarker.png",
             "gameplay/PrimaryMissMarker.png",
             "gameplay/SecondaryHitMarker.png",
             "gameplay/SecondaryMissMarker.png",
             "gameplay/SecondaryTarget.png",
+
+            "gameplay/IdleSurrenderButton.png",
+            "gameplay/ActiveSurrenderButton.png",
+            "gameplay/IdleInstructionsButton.png",
+            "gameplay/ActiveInstructionsButton.png",
     };
 
     const vector<sprite> sprites = {
@@ -87,26 +91,6 @@ Gameplay::Gameplay() : ScreenTemplate() {
     Target::initializeTextures();
     this->setTargetVector();
     this->createCoordinateSet();
-
-    //    loadTexture(this->primaryHitMarkerTexture, "gameplay/PrimaryHitMarker.png");
-    //    loadTexture(this->primaryMissMarkerTexture, "gameplay/PrimaryMissMarker.png");
-    //    loadTexture(this->secondaryHitMarkerTexture, "gameplay/SecondaryHitMarker.png");
-    //    loadTexture(this->secondaryMissMarkerTexture, "gameplay/SecondaryMissMarker.png");
-
-
-    //    loadTexture(this->secondaryTargetTexture, "gameplay/SecondaryTarget.png");
-    //
-    //    this->primaryHitMarkerSprite.setTexture(this->primaryHitMarkerTexture);
-    //    this->primaryHitMarkerSprite.setScale(sf::Vector2f(5, 5));
-    //    this->primaryMissMarkerSprite.setTexture(this->primaryMissMarkerTexture);
-    //    this->primaryMissMarkerSprite.setScale(sf::Vector2f(5, 5));
-    //    this->secondaryHitMarkerSprite.setTexture(this->secondaryHitMarkerTexture);
-    //    this->secondaryHitMarkerSprite.setScale(sf::Vector2f(5, 5));
-    //    this->secondaryMissMarkerSprite.setTexture(this->secondaryMissMarkerTexture);
-    //    this->secondaryMissMarkerSprite.setScale(sf::Vector2f(5, 5));
-    //
-    //    this->secondaryTargetSprite.setTexture(this->secondaryTargetTexture);
-    //    this->secondaryTargetSprite.setScale(sf::Vector2f(5, 5));
 }
 
 void Gameplay::setP1Grid(const shipOrientations &ships) {

--- a/src/screens/gameplay.cpp
+++ b/src/screens/gameplay.cpp
@@ -30,15 +30,16 @@ Gameplay::Gameplay() : ScreenTemplate() {
                                          "gameplay/GameplayP2Background.png",
                                          "gameplay/IdleSurrenderButton.png", "gameplay/ActiveSurrenderButton.png",
                                          "gameplay/IdleInstructionsButton.png", "gameplay/ActiveInstructionsButton.png",
-                                         "gameplay/BattleShip.png", "gameplay/AircraftCarrier.png", "gameplay/Destroyer.png",
+                                         "gameplay/Battleship.png", "gameplay/AircraftCarrier.png", "gameplay/Destroyer.png",
                                          "gameplay/Submarine.png", "gameplay/PatrolBoat.png", "gameplay/RowBoat.png",
-                                         "gameplay/BattleShipSunk.png", "gameplay/AircraftCarrierSunk.png", "gameplay/DestroyerSunk.png",
+                                         "gameplay/BattleshipSunk.png", "gameplay/AircraftCarrierSunk.png", "gameplay/DestroyerSunk.png",
                                          "gameplay/SubmarineSunk.png", "gameplay/PatrolBoatSunk.png", "gameplay/RowBoatSunk.png",
                                          "gameplay/PrimaryHitMarker.png", "gameplay/PrimaryMissMarker.png",
                                          "gameplay/SecondaryHitMarker.png", "gameplay/SecondaryMissMarker.png",
                                          "gameplay/SecondaryTarget.png"};
     const vector<sprite> sprites = {};
-    const vector<button> buttons = {};
+    const vector<button> buttons = {{sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), IdleSurrenderButton, ActiveSurrenderButton},
+                                    {sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), IdleInstructionsButton, ActiveInstructionsButton}};
 
     this->resources = ScreenResourceManager(texturePaths, sprites, buttons);
 
@@ -51,14 +52,14 @@ Gameplay::Gameplay() : ScreenTemplate() {
     loadTexture(this->idleInstructionsButtonTexture, "gameplay/IdleInstructionsButton.png");
     loadTexture(this->activeInstructionsButtonTexture, "gameplay/ActiveInstructionsButton.png");
 
-    loadTexture(this->battleshipTexture, "gameplay/BattleShip.png");
+    loadTexture(this->battleshipTexture, "gameplay/Battleship.png");
     loadTexture(this->aircraftCarrierTexture, "gameplay/AircraftCarrier.png");
     loadTexture(this->destroyerTexture, "gameplay/Destroyer.png");
     loadTexture(this->submarineTexture, "gameplay/Submarine.png");
     loadTexture(this->patrolBoatTexture, "gameplay/PatrolBoat.png");
     loadTexture(this->rowBoatTexture, "gameplay/RowBoat.png");
 
-    loadTexture(this->battleshipSunkTexture, "gameplay/BattleShipSunk.png");
+    loadTexture(this->battleshipSunkTexture, "gameplay/BattleshipSunk.png");
     loadTexture(this->aircraftCarrierSunkTexture, "gameplay/AircraftCarrierSunk.png");
     loadTexture(this->destroyerSunkTexture, "gameplay/DestroyerSunk.png");
     loadTexture(this->submarineSunkTexture, "gameplay/SubmarineSunk.png");
@@ -109,8 +110,8 @@ Gameplay::Gameplay() : ScreenTemplate() {
     this->secondaryTargetSprite.setTexture(this->secondaryTargetTexture);
     this->secondaryTargetSprite.setScale(sf::Vector2f(5, 5));
 
-    this->surrenderButton = new Button(sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), this->idleSurrenderButtonTexture, this->activeSurrenderButtonTexture);
-    this->instructionsButton = new Button(sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), this->idleInstructionsButtonTexture, this->activeInstructionsButtonTexture);
+    // this->surrenderButton = new Button(sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), this->idleSurrenderButtonTexture, this->activeSurrenderButtonTexture);
+    // this->instructionsButton = new Button(sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), this->idleInstructionsButtonTexture, this->activeInstructionsButtonTexture);
 
     this->setTargetVector();
     this->createCoordinateSet();
@@ -123,6 +124,7 @@ void Gameplay::setP1Grid(const shipOrientations &ships) {
 }
 
 void Gameplay::setP2Grid(const shipOrientations &ships) {
+    // TODO
     gridP2.reset(new Grid(ships));
     fleetLayoutP2.reset(&gridP2->getShips());
 }
@@ -386,6 +388,8 @@ void Gameplay::setFleetLayout(shipOrientations &fleetLayout) {
 void Gameplay::update() {
     sf::Vector2f mousePosition = State::getMousePosition();
 
+    // resources.getButton(Surrender).updateButtonState(mousePosition);
+    // resources.getButton(Surrender).updateButtonState(mousePosition);
     this->surrenderButton->updateButtonState(mousePosition);
     this->instructionsButton->updateButtonState(mousePosition);
 

--- a/src/screens/gameplay.cpp
+++ b/src/screens/gameplay.cpp
@@ -26,64 +26,87 @@ Gameplay::Gameplay() : ScreenTemplate() {
     fleetLayoutP1 = std::make_unique<shipOrientations>();
     fleetLayoutP2 = std::make_unique<shipOrientations>();
 
-    const vector<string> texturePaths = {"gameplay/GameplayBackground.png", "gameplay/GameplayP1Background.png",
-                                         "gameplay/GameplayP2Background.png",
-                                         "gameplay/IdleSurrenderButton.png", "gameplay/ActiveSurrenderButton.png",
-                                         "gameplay/IdleInstructionsButton.png", "gameplay/ActiveInstructionsButton.png",
-                                         "gameplay/Battleship.png", "gameplay/AircraftCarrier.png", "gameplay/Destroyer.png",
-                                         "gameplay/Submarine.png", "gameplay/PatrolBoat.png", "gameplay/RowBoat.png",
-                                         "gameplay/BattleshipSunk.png", "gameplay/AircraftCarrierSunk.png", "gameplay/DestroyerSunk.png",
-                                         "gameplay/SubmarineSunk.png", "gameplay/PatrolBoatSunk.png", "gameplay/RowBoatSunk.png",
-                                         "gameplay/PrimaryHitMarker.png", "gameplay/PrimaryMissMarker.png",
-                                         "gameplay/SecondaryHitMarker.png", "gameplay/SecondaryMissMarker.png",
-                                         "gameplay/SecondaryTarget.png"};
+    const vector<string> texturePaths = {
+            "gameplay/GameplayBackground.png",
+            "gameplay/GameplayP1Background.png",
+            "gameplay/GameplayP2Background.png",
+            "gameplay/IdleSurrenderButton.png",
+            "gameplay/ActiveSurrenderButton.png",
+            "gameplay/IdleInstructionsButton.png",
+            "gameplay/ActiveInstructionsButton.png",
+            "gameplay/Battleship.png",
+            "gameplay/AircraftCarrier.png",
+            "gameplay/Destroyer.png",
+            "gameplay/Submarine.png",
+            "gameplay/PatrolBoat.png",
+            "gameplay/RowBoat.png",
+            "gameplay/BattleshipSunk.png",
+            "gameplay/AircraftCarrierSunk.png",
+            "gameplay/DestroyerSunk.png",
+            "gameplay/SubmarineSunk.png",
+            "gameplay/PatrolBoatSunk.png",
+            "gameplay/RowBoatSunk.png",
+            "gameplay/PrimaryHitMarker.png",
+            "gameplay/PrimaryMissMarker.png",
+            "gameplay/SecondaryHitMarker.png",
+            "gameplay/SecondaryMissMarker.png",
+            "gameplay/SecondaryTarget.png",
+    };
 
-    const vector<sprite> sprites = {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), BackgroundDefault_},
-                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), BackgroundP1_},
-                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), BackgroundP2_},
+    const vector<sprite> sprites = {
+            {sf::Vector2f(0, 0), sf::Vector2f(5, 5), BackgroundDefault_},
+            {sf::Vector2f(0, 0), sf::Vector2f(5, 5), BackgroundP1_},
+            {sf::Vector2f(0, 0), sf::Vector2f(5, 5), BackgroundP2_},
 
-                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), Battleship_},
-                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), AircraftCarrier_},
-                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), Destroyer_},
-                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), Submarine_},
-                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), PatrolBoat_},
-                                    {sf::Vector2f(0, 0), sf::Vector2f(5, 5), RowBoat_},
+            {sf::Vector2f(0, 0), sf::Vector2f(5, 5), Battleship_},
+            {sf::Vector2f(0, 0), sf::Vector2f(5, 5), AircraftCarrier_},
+            {sf::Vector2f(0, 0), sf::Vector2f(5, 5), Destroyer_},
+            {sf::Vector2f(0, 0), sf::Vector2f(5, 5), Submarine_},
+            {sf::Vector2f(0, 0), sf::Vector2f(5, 5), PatrolBoat_},
+            {sf::Vector2f(0, 0), sf::Vector2f(5, 5), RowBoat_},
 
-                                    {sf::Vector2f(330 * 5, 113 * 5), sf::Vector2f(5, 5), BattleshipSunk_},
-                                    {sf::Vector2f(348 * 5, 117 * 5), sf::Vector2f(5, 5), AircraftCarrierSunk_},
-                                    {sf::Vector2f(348 * 5, 75 * 5), sf::Vector2f(5, 5), DestroyerSunk_},
-                                    {sf::Vector2f(330 * 5, 79 * 5), sf::Vector2f(5, 5), SubmarineSunk_},
-                                    {sf::Vector2f(330 * 5, 53 * 5), sf::Vector2f(5, 5), PatrolBoatSunk_},
-                                    {sf::Vector2f(348 * 5, 57 * 5), sf::Vector2f(5, 5), RowBoatSunk_}};
+            {sf::Vector2f(330 * 5, 113 * 5), sf::Vector2f(5, 5), BattleshipSunk_},
+            {sf::Vector2f(348 * 5, 117 * 5), sf::Vector2f(5, 5), AircraftCarrierSunk_},
+            {sf::Vector2f(348 * 5, 75 * 5), sf::Vector2f(5, 5), DestroyerSunk_},
+            {sf::Vector2f(330 * 5, 79 * 5), sf::Vector2f(5, 5), SubmarineSunk_},
+            {sf::Vector2f(330 * 5, 53 * 5), sf::Vector2f(5, 5), PatrolBoatSunk_},
+            {sf::Vector2f(348 * 5, 57 * 5), sf::Vector2f(5, 5), RowBoatSunk_},
+
+            {sf::Vector2f(0, 0), sf::Vector2f(5, 5), PrimaryHitMarker_},
+            {sf::Vector2f(0, 0), sf::Vector2f(5, 5), PrimaryMissMarker_},
+            {sf::Vector2f(0, 0), sf::Vector2f(5, 5), SecondaryHitMarker_},
+            {sf::Vector2f(0, 0), sf::Vector2f(5, 5), SecondaryMissMarker_},
+            {sf::Vector2f(0, 0), sf::Vector2f(5, 5), SecondaryTarget_},
+    };
 
     const vector<button> buttons = {{sf::Vector2f(320 * 5, 12 * 5), sf::Vector2f(5, 5), IdleSurrenderButton, ActiveSurrenderButton},
                                     {sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), IdleInstructionsButton, ActiveInstructionsButton}};
 
     this->resources = ScreenResourceManager(texturePaths, sprites, buttons);
 
-
-    loadTexture(this->primaryHitMarkerTexture, "gameplay/PrimaryHitMarker.png");
-    loadTexture(this->primaryMissMarkerTexture, "gameplay/PrimaryMissMarker.png");
-    loadTexture(this->secondaryHitMarkerTexture, "gameplay/SecondaryHitMarker.png");
-    loadTexture(this->secondaryMissMarkerTexture, "gameplay/SecondaryMissMarker.png");
-
     Target::initializeTextures();
-    loadTexture(this->secondaryTargetTexture, "gameplay/SecondaryTarget.png");
-
-    this->primaryHitMarkerSprite.setTexture(this->primaryHitMarkerTexture);
-    this->primaryHitMarkerSprite.setScale(sf::Vector2f(5, 5));
-    this->primaryMissMarkerSprite.setTexture(this->primaryMissMarkerTexture);
-    this->primaryMissMarkerSprite.setScale(sf::Vector2f(5, 5));
-    this->secondaryHitMarkerSprite.setTexture(this->secondaryHitMarkerTexture);
-    this->secondaryHitMarkerSprite.setScale(sf::Vector2f(5, 5));
-    this->secondaryMissMarkerSprite.setTexture(this->secondaryMissMarkerTexture);
-    this->secondaryMissMarkerSprite.setScale(sf::Vector2f(5, 5));
-
-    this->secondaryTargetSprite.setTexture(this->secondaryTargetTexture);
-    this->secondaryTargetSprite.setScale(sf::Vector2f(5, 5));
-
     this->setTargetVector();
     this->createCoordinateSet();
+
+    //    loadTexture(this->primaryHitMarkerTexture, "gameplay/PrimaryHitMarker.png");
+    //    loadTexture(this->primaryMissMarkerTexture, "gameplay/PrimaryMissMarker.png");
+    //    loadTexture(this->secondaryHitMarkerTexture, "gameplay/SecondaryHitMarker.png");
+    //    loadTexture(this->secondaryMissMarkerTexture, "gameplay/SecondaryMissMarker.png");
+
+
+    //    loadTexture(this->secondaryTargetTexture, "gameplay/SecondaryTarget.png");
+    //
+    //    this->primaryHitMarkerSprite.setTexture(this->primaryHitMarkerTexture);
+    //    this->primaryHitMarkerSprite.setScale(sf::Vector2f(5, 5));
+    //    this->primaryMissMarkerSprite.setTexture(this->primaryMissMarkerTexture);
+    //    this->primaryMissMarkerSprite.setScale(sf::Vector2f(5, 5));
+    //    this->secondaryHitMarkerSprite.setTexture(this->secondaryHitMarkerTexture);
+    //    this->secondaryHitMarkerSprite.setScale(sf::Vector2f(5, 5));
+    //    this->secondaryMissMarkerSprite.setTexture(this->secondaryMissMarkerTexture);
+    //    this->secondaryMissMarkerSprite.setScale(sf::Vector2f(5, 5));
+    //
+    //    this->secondaryTargetSprite.setTexture(this->secondaryTargetTexture);
+    //    this->secondaryTargetSprite.setScale(sf::Vector2f(5, 5));
 }
 
 void Gameplay::setP1Grid(const shipOrientations &ships) {
@@ -137,50 +160,52 @@ void Gameplay::updateGridMarkers(SquareType attack, Coordinate coordinate) {
     if (State::gameMode == State::GameMode::SINGLE_PLAYER) {
         if (State::player == State::Player::P1) {
             if (attack == SquareType::WATER) {
-                this->primaryMissMarkerSprite.setPosition(sf::Vector2f(((128 + (coordinate.getX() * 16)) * 5), ((28 + (coordinate.getY() * 16)) * 5)));
-                this->primaryMarkersP1Vector.push_back(this->primaryMissMarkerSprite);
+                resources.getSprite(PrimaryMissMarker).setPosition(sf::Vector2f(((128 + (coordinate.getX() * 16)) * 5), ((28 + (coordinate.getY() * 16)) * 5)));
+                this->primaryMarkersP1Vector.push_back(resources.getSprite(PrimaryMissMarker));
             } else {
-                this->primaryHitMarkerSprite.setPosition(sf::Vector2f(((128 + (coordinate.getX() * 16)) * 5), ((28 + (coordinate.getY() * 16)) * 5)));
-                this->primaryMarkersP1Vector.push_back(this->primaryHitMarkerSprite);
+                resources.getSprite(PrimaryHitMarker).setPosition(sf::Vector2f(((128 + (coordinate.getX() * 16)) * 5), ((28 + (coordinate.getY() * 16)) * 5)));
+                this->primaryMarkersP1Vector.push_back(resources.getSprite(PrimaryHitMarker));
             }
         } else {
             if (attack == SquareType::WATER) {
-                this->secondaryMissMarkerSprite.setPosition(sf::Vector2f(((16 + (coordinate.getX() * 8)) * 5), ((44 + (coordinate.getY() * 8)) * 5)));
-                this->secondaryMarkersP1Vector.push_back(this->secondaryMissMarkerSprite);
+                resources.getSprite(SecondaryMissMarker).setPosition(sf::Vector2f(((16 + (coordinate.getX() * 8)) * 5), ((44 + (coordinate.getY() * 8)) * 5)));
+                this->secondaryMarkersP1Vector.push_back(resources.getSprite(SecondaryMissMarker));
             } else {
-                this->secondaryHitMarkerSprite.setPosition(sf::Vector2f(((16 + (coordinate.getX() * 8)) * 5), ((44 + (coordinate.getY() * 8)) * 5)));
-                this->secondaryMarkersP1Vector.push_back(this->secondaryHitMarkerSprite);
+                resources.getSprite(SecondaryHitMarker).setPosition(sf::Vector2f(((16 + (coordinate.getX() * 8)) * 5), ((44 + (coordinate.getY() * 8)) * 5)));
+                this->secondaryMarkersP1Vector.push_back(resources.getSprite(SecondaryHitMarker));
             }
         }
 
     } else {
         if (State::player == State::Player::P1) {
             if (attack == SquareType::WATER) {
-                this->primaryMissMarkerSprite.setPosition(sf::Vector2f(((128 + (coordinate.getX() * 16)) * 5), ((28 + (coordinate.getY() * 16)) * 5)));
-                this->primaryMarkersP1Vector.push_back(this->primaryMissMarkerSprite);
+                resources.getSprite(PrimaryMissMarker)
+                        .setPosition(sf::Vector2f(((128 + (coordinate.getX() * 16)) * 5), ((28 + (coordinate.getY() * 16)) * 5)));
+                this->primaryMarkersP1Vector.push_back(resources.getSprite(PrimaryMissMarker));
 
-                this->secondaryMissMarkerSprite.setPosition(sf::Vector2f(((16 + (coordinate.getX() * 8)) * 5), ((44 + (coordinate.getY() * 8)) * 5)));
-                this->secondaryMarkersP2Vector.push_back(this->secondaryMissMarkerSprite);
+                resources.getSprite(SecondaryMissMarker).setPosition(sf::Vector2f(((16 + (coordinate.getX() * 8)) * 5), ((44 + (coordinate.getY() * 8)) * 5)));
+                this->secondaryMarkersP2Vector.push_back(resources.getSprite(SecondaryMissMarker));
             } else {
-                this->primaryHitMarkerSprite.setPosition(sf::Vector2f(((128 + (coordinate.getX() * 16)) * 5), ((28 + (coordinate.getY() * 16)) * 5)));
-                this->primaryMarkersP1Vector.push_back(this->primaryHitMarkerSprite);
+                resources.getSprite(PrimaryHitMarker).setPosition(sf::Vector2f(((128 + (coordinate.getX() * 16)) * 5), ((28 + (coordinate.getY() * 16)) * 5)));
+                this->primaryMarkersP1Vector.push_back(resources.getSprite(PrimaryHitMarker));
 
-                this->secondaryHitMarkerSprite.setPosition(sf::Vector2f(((16 + (coordinate.getX() * 8)) * 5), ((44 + (coordinate.getY() * 8)) * 5)));
-                this->secondaryMarkersP2Vector.push_back(this->secondaryHitMarkerSprite);
+                resources.getSprite(SecondaryHitMarker).setPosition(sf::Vector2f(((16 + (coordinate.getX() * 8)) * 5), ((44 + (coordinate.getY() * 8)) * 5)));
+                this->secondaryMarkersP2Vector.push_back(resources.getSprite(SecondaryHitMarker));
             }
         } else {
             if (attack == SquareType::WATER) {
-                this->primaryMissMarkerSprite.setPosition(sf::Vector2f(((128 + (coordinate.getX() * 16)) * 5), ((28 + (coordinate.getY() * 16)) * 5)));
-                this->primaryMarkersP2Vector.push_back(this->primaryMissMarkerSprite);
+                resources.getSprite(PrimaryMissMarker)
+                        .setPosition(sf::Vector2f(((128 + (coordinate.getX() * 16)) * 5), ((28 + (coordinate.getY() * 16)) * 5)));
+                this->primaryMarkersP2Vector.push_back(resources.getSprite(PrimaryMissMarker));
 
-                this->secondaryMissMarkerSprite.setPosition(sf::Vector2f(((16 + (coordinate.getX() * 8)) * 5), ((44 + (coordinate.getY() * 8)) * 5)));
-                this->secondaryMarkersP1Vector.push_back(this->secondaryMissMarkerSprite);
+                resources.getSprite(SecondaryMissMarker).setPosition(sf::Vector2f(((16 + (coordinate.getX() * 8)) * 5), ((44 + (coordinate.getY() * 8)) * 5)));
+                this->secondaryMarkersP1Vector.push_back(resources.getSprite(SecondaryMissMarker));
             } else {
-                this->primaryHitMarkerSprite.setPosition(sf::Vector2f(((128 + (coordinate.getX() * 16)) * 5), ((28 + (coordinate.getY() * 16)) * 5)));
-                this->primaryMarkersP2Vector.push_back(this->primaryHitMarkerSprite);
+                resources.getSprite(PrimaryHitMarker).setPosition(sf::Vector2f(((128 + (coordinate.getX() * 16)) * 5), ((28 + (coordinate.getY() * 16)) * 5)));
+                this->primaryMarkersP2Vector.push_back(resources.getSprite(PrimaryHitMarker));
 
-                this->secondaryHitMarkerSprite.setPosition(sf::Vector2f(((16 + (coordinate.getX() * 8)) * 5), ((44 + (coordinate.getY() * 8)) * 5)));
-                this->secondaryMarkersP1Vector.push_back(this->secondaryHitMarkerSprite);
+                resources.getSprite(SecondaryHitMarker).setPosition(sf::Vector2f(((16 + (coordinate.getX() * 8)) * 5), ((44 + (coordinate.getY() * 8)) * 5)));
+                this->secondaryMarkersP1Vector.push_back(resources.getSprite(SecondaryHitMarker));
             }
         }
     }
@@ -194,7 +219,8 @@ void Gameplay::resetGridMarkers() {
 }
 
 void Gameplay::updateSecondaryTarget(Coordinate coordinate) {
-    this->secondaryTargetSprite.setPosition(sf::Vector2f(((16 + (coordinate.getX() * 8)) * 5), ((44 + (coordinate.getY() * 8)) * 5)));
+    resources.getSprite(SecondaryTarget)
+            .setPosition(sf::Vector2f(((16 + (coordinate.getX() * 8)) * 5), ((44 + (coordinate.getY() * 8)) * 5)));
 }
 
 void Gameplay::updateGrid(Coordinate &coordinate, sf::RenderWindow &gui) {
@@ -506,11 +532,11 @@ void Gameplay::render() {
     }
 
     if ((State::player == State::Player::P1) && !this->secondaryMarkersP1Vector.empty()) {
-        gui.draw(this->secondaryTargetSprite);
+        gui.draw(resources.getSprite(SecondaryTarget));
     }
 
     if ((State::player == State::Player::P2) && !this->secondaryMarkersP2Vector.empty()) {
-        gui.draw(this->secondaryTargetSprite);
+        gui.draw(resources.getSprite(SecondaryTarget));
     }
 
     if (State::gameMode == State::SINGLE_PLAYER) {

--- a/src/screens/gameplay.hpp
+++ b/src/screens/gameplay.hpp
@@ -88,11 +88,11 @@ namespace screen {
             PatrolBoatSunk_,
             RowBoatSunk_,
 
-            PrimaryHitMarker,
-            PrimaryMissMarker,
-            SecondaryHitMarker,
-            SecondaryMissMarker,
-            SecondaryTarget
+            PrimaryHitMarker_,
+            PrimaryMissMarker_,
+            SecondaryHitMarker_,
+            SecondaryMissMarker_,
+            SecondaryTarget_
         };
         enum spriteNames {
             BackgroundDefault,
@@ -111,7 +111,13 @@ namespace screen {
             DestroyerSunk,
             SubmarineSunk,
             PatrolBoatSunk,
-            RowBoatSunk
+            RowBoatSunk,
+
+            PrimaryHitMarker,
+            PrimaryMissMarker,
+            SecondaryHitMarker,
+            SecondaryMissMarker,
+            SecondaryTarget
         };
         enum buttonNames {
             Surrender,
@@ -205,20 +211,20 @@ namespace screen {
         static constexpr int sleepTimeMS = 400;
 
 
-        sf::Texture primaryHitMarkerTexture;
-        sf::Texture primaryMissMarkerTexture;
-        sf::Texture secondaryHitMarkerTexture;
-        sf::Texture secondaryMissMarkerTexture;
-        sf::Texture idlePrimaryTargetTexture;
-        sf::Texture activePrimaryTargetTexture;
-        sf::Texture secondaryTargetTexture;
-
-
-        sf::Sprite primaryHitMarkerSprite;
-        sf::Sprite primaryMissMarkerSprite;
-        sf::Sprite secondaryHitMarkerSprite;
-        sf::Sprite secondaryMissMarkerSprite;
-        sf::Sprite secondaryTargetSprite;
+//        sf::Texture primaryHitMarkerTexture;
+//        sf::Texture primaryMissMarkerTexture;
+//        sf::Texture secondaryHitMarkerTexture;
+//        sf::Texture secondaryMissMarkerTexture;
+//        sf::Texture idlePrimaryTargetTexture;
+//        sf::Texture activePrimaryTargetTexture;
+//        sf::Texture secondaryTargetTexture;
+//
+//
+//        sf::Sprite primaryHitMarkerSprite;
+//        sf::Sprite primaryMissMarkerSprite;
+//        sf::Sprite secondaryHitMarkerSprite;
+//        sf::Sprite secondaryMissMarkerSprite;
+//        sf::Sprite secondaryTargetSprite;
 
         vector<Target> targetVector;
 

--- a/src/screens/gameplay.hpp
+++ b/src/screens/gameplay.hpp
@@ -42,6 +42,7 @@ namespace screen {
         /**
          * Initializes P1 grid
          */
+         // TODO: take out the static part
         static void setP1Grid(const map<shipNames, tuple<Coordinate, bool>> &ships);
 
         /**
@@ -50,15 +51,56 @@ namespace screen {
         static void setP2Grid(const map<shipNames, tuple<Coordinate, bool>> &ships);
 
     private:
-        /**
-         * Constructor
-         */
+        // Singleton instance
+        static std::unique_ptr<Gameplay> instance;
+
+        // Singleton constructor
         Gameplay();
 
-        /**
-         *
-         */
-        static Gameplay *instance;
+        // SFML event loop helpers
+        void update() override;
+        void poll() override;
+        void render() override;
+
+        // Names to refer to resources on this screen
+        enum textureNames {
+            BackgroundDefault_,
+            BackgroundP1_,
+            BackgroundP2_,
+            IdleReadyButton,
+            ActiveReadyButton,
+            IdleRandomizeButton,
+            ActiveRandomizeButton,
+            IdleInstructionsButton,
+            ReadyInstructionsButton,
+            Battleship_,
+            AircraftCarrier_,
+            Destroyer_,
+            Submarine_,
+            PatrolBoat_,
+            RowBoat_
+        };
+        enum spriteNames {
+            BackgroundDefault,
+            BackgroundP1,
+            BackgroundP2,
+            Battleship,
+            AircraftCarrier,
+            Destroyer,
+            Submarine,
+            PatrolBoat,
+            RowBoat
+        };
+        enum buttonNames {
+            Ready,
+            Randomize,
+            Instructions
+        };
+
+
+
+
+
 
         /**
          * Map of P1 fleet layout
@@ -136,293 +178,71 @@ namespace screen {
         void setFleetLayout(map<shipNames, tuple<Coordinate, bool>> &fleetLayout);
 
         /**
-         * Calls helpers::updateMousePosition(), Button::updateButtonState(), Target::updateTargetState(), Grid::getShips(), and Gameplay::setFleetLayout()
-         */
-        void update();
-
-        /**
-         * Polls for system events
-         */
-        void poll();
-
-        /**
          * Renders ship status
          */
         void renderShipStatus(Grid &grid);
-
-        /**
-         * Renders all sprites
-         */
-        void render();
 
         /**
          * The sleep time after a player attacks in milliseconds
          */
         static constexpr int sleepTimeMS = 400;
 
-        /**
-         * Default 1 Player background texture
-         */
+
         sf::Texture gameplayDefaultBackgroundTexture;
-
-        /**
-         * P1 background texture
-         */
         sf::Texture gameplayP1BackgroundTexture;
-
-        /**
-         * P2 background texture
-         */
         sf::Texture gameplayP2BackgroundTexture;
-
-        /**
-         * Idle surrender button texture
-         */
         sf::Texture idleSurrenderButtonTexture;
-
-        /**
-         * Active surrender button texture
-         */
         sf::Texture activeSurrenderButtonTexture;
-
-        /**
-         * Idle instructions button texture
-         */
         sf::Texture idleInstructionsButtonTexture;
-
-        /**
-         * Active instructions button texture
-         */
         sf::Texture activeInstructionsButtonTexture;
-
-        /**
-         * Battleship texture
-         */
         sf::Texture battleshipTexture;
-
-        /**
-         * Aircraft carrier texture
-         */
         sf::Texture aircraftCarrierTexture;
-
-        /**
-         * Destroyer texture
-         */
         sf::Texture destroyerTexture;
-
-        /**
-         * Submarine texture
-         */
         sf::Texture submarineTexture;
-
-        /**
-         * Patrol boat texture
-         */
         sf::Texture patrolBoatTexture;
-
-        /**
-         * Row boat texture
-         */
         sf::Texture rowBoatTexture;
-
-        /**
-         * Battleship sunk texture
-         */
         sf::Texture battleshipSunkTexture;
-
-        /**
-         * Aircraft carrier sunk texture
-         */
         sf::Texture aircraftCarrierSunkTexture;
-
-        /**
-         * Destroyer sunk texture
-         */
         sf::Texture destroyerSunkTexture;
-
-        /**
-         * Submarine sunk texture
-         */
         sf::Texture submarineSunkTexture;
-
-        /**
-         * Patrol boat sunk texture
-         */
         sf::Texture patrolBoatSunkTexture;
-
-        /**
-         * Row boat sunk texture
-         */
         sf::Texture rowBoatSunkTexture;
-
-        /**
-         * Primary hit marker texture
-         */
         sf::Texture primaryHitMarkerTexture;
-
-        /**
-         * Primary miss marker texture
-         */
         sf::Texture primaryMissMarkerTexture;
-
-        /**
-         * Secondary hit marker texture
-         */
         sf::Texture secondaryHitMarkerTexture;
-
-        /**
-         * Secondary miss marker texture
-         */
         sf::Texture secondaryMissMarkerTexture;
-
-        /**
-         * Idle Primary target texture
-         */
         sf::Texture idlePrimaryTargetTexture;
-
-        /**
-         * Active primary target texture
-         */
         sf::Texture activePrimaryTargetTexture;
-
-        /**
-         * Secondary target texture
-         */
         sf::Texture secondaryTargetTexture;
-
-        /**
-         * Default 1 player background sprite
-         */
         sf::Sprite backgroundDefaultSprite;
-
-        /**
-         * P1 background sprite
-         */
         sf::Sprite backgroundP1Sprite;
-
-        /**
-         * P2 background sprite
-         */
         sf::Sprite backgroundP2Sprite;
-
-        /**
-         * Battleship sprite
-         */
         sf::Sprite battleshipSprite;
-
-        /**
-         * Aircraft carrier sprite
-         */
         sf::Sprite aircraftCarrierSprite;
-
-        /**
-         * Destroyer sprite
-         */
         sf::Sprite destroyerSprite;
-
-        /**
-         * Submarine sprite
-         */
         sf::Sprite submarineSprite;
-
-        /**
-         * Patrol Boat sprite
-         */
         sf::Sprite patrolBoatSprite;
-
-        /**
-         * Row boat sprite
-         */
         sf::Sprite rowBoatSprite;
-
-        /**
-         * Battleship sunk sprite
-         */
         sf::Sprite battleshipSunkSprite;
-
-        /**
-         * Aircraft carrier sunk sprite
-         */
         sf::Sprite aircraftCarrierSunkSprite;
-
-        /**
-         * Destroyer sunk sprite
-         */
         sf::Sprite destroyerSunkSprite;
-
-        /**
-         * Submarine sunk sprite
-         */
         sf::Sprite submarineSunkSprite;
-
-        /**
-         * Patrol boat sunk sprite
-         */
         sf::Sprite patrolBoatSunkSprite;
-
-        /**
-         * Row boat sunksprite
-         */
         sf::Sprite rowBoatSunkSprite;
-
-        /**
-         * Primary hit marker sprite
-         */
         sf::Sprite primaryHitMarkerSprite;
-
-        /**
-         * Primary miss marker sprite
-         */
         sf::Sprite primaryMissMarkerSprite;
-
-        /**
-         * Secondary hit marker sprite
-         */
         sf::Sprite secondaryHitMarkerSprite;
-
-        /**
-         * Secondary miss marker sprite
-         */
         sf::Sprite secondaryMissMarkerSprite;
-
-        /**
-         * Secondary target sprite
-         */
         sf::Sprite secondaryTargetSprite;
 
-        /**
-         * Surrender button 
-         */
         Button *surrenderButton;
-
-        /**
-         * Instructions button 
-         */
         Button *instructionsButton;
 
-        /**
-         * Vector of targets
-         */
         vector<Target> targetVector;
 
-        /**
-         * Vector of P1 primary markers
-         */
         vector<sf::Sprite> primaryMarkersP1Vector;
-
-        /**
-         * Vector of P2 primary markers
-         */
         vector<sf::Sprite> primaryMarkersP2Vector;
-
-        /**
-         * Vector of P1 secondary markers
-         */
         vector<sf::Sprite> secondaryMarkersP1Vector;
-
-        /**
-         * Vector of P2 secondary markers
-         */
         vector<sf::Sprite> secondaryMarkersP2Vector;
     };
 }// namespace screen

--- a/src/screens/gameplay.hpp
+++ b/src/screens/gameplay.hpp
@@ -197,25 +197,20 @@ namespace screen {
         static constexpr int sleepTimeMS = 400;
 
 
-        sf::Texture gameplayDefaultBackgroundTexture;
-        sf::Texture gameplayP1BackgroundTexture;
-        sf::Texture gameplayP2BackgroundTexture;
-        sf::Texture idleSurrenderButtonTexture;
-        sf::Texture activeSurrenderButtonTexture;
-        sf::Texture idleInstructionsButtonTexture;
-        sf::Texture activeInstructionsButtonTexture;
         sf::Texture battleshipTexture;
         sf::Texture aircraftCarrierTexture;
         sf::Texture destroyerTexture;
         sf::Texture submarineTexture;
         sf::Texture patrolBoatTexture;
         sf::Texture rowBoatTexture;
+
         sf::Texture battleshipSunkTexture;
         sf::Texture aircraftCarrierSunkTexture;
         sf::Texture destroyerSunkTexture;
         sf::Texture submarineSunkTexture;
         sf::Texture patrolBoatSunkTexture;
         sf::Texture rowBoatSunkTexture;
+
         sf::Texture primaryHitMarkerTexture;
         sf::Texture primaryMissMarkerTexture;
         sf::Texture secondaryHitMarkerTexture;
@@ -223,29 +218,27 @@ namespace screen {
         sf::Texture idlePrimaryTargetTexture;
         sf::Texture activePrimaryTargetTexture;
         sf::Texture secondaryTargetTexture;
-        sf::Sprite backgroundDefaultSprite;
-        sf::Sprite backgroundP1Sprite;
-        sf::Sprite backgroundP2Sprite;
+
+
         sf::Sprite battleshipSprite;
         sf::Sprite aircraftCarrierSprite;
         sf::Sprite destroyerSprite;
         sf::Sprite submarineSprite;
         sf::Sprite patrolBoatSprite;
         sf::Sprite rowBoatSprite;
+
         sf::Sprite battleshipSunkSprite;
         sf::Sprite aircraftCarrierSunkSprite;
         sf::Sprite destroyerSunkSprite;
         sf::Sprite submarineSunkSprite;
         sf::Sprite patrolBoatSunkSprite;
         sf::Sprite rowBoatSunkSprite;
+
         sf::Sprite primaryHitMarkerSprite;
         sf::Sprite primaryMissMarkerSprite;
         sf::Sprite secondaryHitMarkerSprite;
         sf::Sprite secondaryMissMarkerSprite;
         sf::Sprite secondaryTargetSprite;
-
-        Button *surrenderButton;
-        Button *instructionsButton;
 
         vector<Target> targetVector;
 

--- a/src/screens/gameplay.hpp
+++ b/src/screens/gameplay.hpp
@@ -81,12 +81,12 @@ namespace screen {
             PatrolBoat_,
             RowBoat_,
 
-            BattleShipSunk,
-            AircraftCarrierSunk,
-            DestroyerSunk,
-            SubmarineSunk,
-            PatrolBoatSunk,
-            RowBoatSunk,
+            BattleShipSunk_,
+            AircraftCarrierSunk_,
+            DestroyerSunk_,
+            SubmarineSunk_,
+            PatrolBoatSunk_,
+            RowBoatSunk_,
 
             PrimaryHitMarker,
             PrimaryMissMarker,
@@ -98,6 +98,12 @@ namespace screen {
             BackgroundDefault,
             BackgroundP1,
             BackgroundP2,
+            BattleShipSunk,
+            AircraftCarrierSunk,
+            DestroyerSunk,
+            SubmarineSunk,
+            PatrolBoatSunk,
+            RowBoatSunk,
             Battleship,
             AircraftCarrier,
             Destroyer,
@@ -204,13 +210,6 @@ namespace screen {
         sf::Texture patrolBoatTexture;
         sf::Texture rowBoatTexture;
 
-        sf::Texture battleshipSunkTexture;
-        sf::Texture aircraftCarrierSunkTexture;
-        sf::Texture destroyerSunkTexture;
-        sf::Texture submarineSunkTexture;
-        sf::Texture patrolBoatSunkTexture;
-        sf::Texture rowBoatSunkTexture;
-
         sf::Texture primaryHitMarkerTexture;
         sf::Texture primaryMissMarkerTexture;
         sf::Texture secondaryHitMarkerTexture;
@@ -226,13 +225,6 @@ namespace screen {
         sf::Sprite submarineSprite;
         sf::Sprite patrolBoatSprite;
         sf::Sprite rowBoatSprite;
-
-        sf::Sprite battleshipSunkSprite;
-        sf::Sprite aircraftCarrierSunkSprite;
-        sf::Sprite destroyerSunkSprite;
-        sf::Sprite submarineSunkSprite;
-        sf::Sprite patrolBoatSunkSprite;
-        sf::Sprite rowBoatSunkSprite;
 
         sf::Sprite primaryHitMarkerSprite;
         sf::Sprite primaryMissMarkerSprite;

--- a/src/screens/gameplay.hpp
+++ b/src/screens/gameplay.hpp
@@ -68,18 +68,31 @@ namespace screen {
             BackgroundDefault_,
             BackgroundP1_,
             BackgroundP2_,
-            IdleReadyButton,
-            ActiveReadyButton,
-            IdleRandomizeButton,
-            ActiveRandomizeButton,
+
+            IdleSurrenderButton,
+            ActiveSurrenderButton,
             IdleInstructionsButton,
-            ReadyInstructionsButton,
+            ActiveInstructionsButton,
+
             Battleship_,
             AircraftCarrier_,
             Destroyer_,
             Submarine_,
             PatrolBoat_,
-            RowBoat_
+            RowBoat_,
+
+            BattleShipSunk,
+            AircraftCarrierSunk,
+            DestroyerSunk,
+            SubmarineSunk,
+            PatrolBoatSunk,
+            RowBoatSunk,
+
+            PrimaryHitMarker,
+            PrimaryMissMarker,
+            SecondaryHitMarker,
+            SecondaryMissMarker,
+            SecondaryTarget
         };
         enum spriteNames {
             BackgroundDefault,
@@ -93,14 +106,9 @@ namespace screen {
             RowBoat
         };
         enum buttonNames {
-            Ready,
-            Randomize,
+            Surrender,
             Instructions
         };
-
-
-
-
 
 
         /**

--- a/src/screens/gameplay.hpp
+++ b/src/screens/gameplay.hpp
@@ -81,7 +81,7 @@ namespace screen {
             PatrolBoat_,
             RowBoat_,
 
-            BattleShipSunk_,
+            BattleshipSunk_,
             AircraftCarrierSunk_,
             DestroyerSunk_,
             SubmarineSunk_,
@@ -98,18 +98,20 @@ namespace screen {
             BackgroundDefault,
             BackgroundP1,
             BackgroundP2,
-            BattleShipSunk,
-            AircraftCarrierSunk,
-            DestroyerSunk,
-            SubmarineSunk,
-            PatrolBoatSunk,
-            RowBoatSunk,
+
             Battleship,
             AircraftCarrier,
             Destroyer,
             Submarine,
             PatrolBoat,
-            RowBoat
+            RowBoat,
+
+            BattleShipSunk,
+            AircraftCarrierSunk,
+            DestroyerSunk,
+            SubmarineSunk,
+            PatrolBoatSunk,
+            RowBoatSunk
         };
         enum buttonNames {
             Surrender,
@@ -203,13 +205,6 @@ namespace screen {
         static constexpr int sleepTimeMS = 400;
 
 
-        sf::Texture battleshipTexture;
-        sf::Texture aircraftCarrierTexture;
-        sf::Texture destroyerTexture;
-        sf::Texture submarineTexture;
-        sf::Texture patrolBoatTexture;
-        sf::Texture rowBoatTexture;
-
         sf::Texture primaryHitMarkerTexture;
         sf::Texture primaryMissMarkerTexture;
         sf::Texture secondaryHitMarkerTexture;
@@ -218,13 +213,6 @@ namespace screen {
         sf::Texture activePrimaryTargetTexture;
         sf::Texture secondaryTargetTexture;
 
-
-        sf::Sprite battleshipSprite;
-        sf::Sprite aircraftCarrierSprite;
-        sf::Sprite destroyerSprite;
-        sf::Sprite submarineSprite;
-        sf::Sprite patrolBoatSprite;
-        sf::Sprite rowBoatSprite;
 
         sf::Sprite primaryHitMarkerSprite;
         sf::Sprite primaryMissMarkerSprite;

--- a/src/screens/gameplay.hpp
+++ b/src/screens/gameplay.hpp
@@ -49,11 +49,6 @@ namespace screen {
          */
         static void setP2Grid(const map<shipNames, tuple<Coordinate, bool>> &ships);
 
-        /**
-         * Overridden run method of screenTemplate
-         */
-        void run() override;
-
     private:
         /**
          * Constructor

--- a/src/screens/gameplay.hpp
+++ b/src/screens/gameplay.hpp
@@ -69,11 +69,6 @@ namespace screen {
             BackgroundP1_,
             BackgroundP2_,
 
-            IdleSurrenderButton,
-            ActiveSurrenderButton,
-            IdleInstructionsButton,
-            ActiveInstructionsButton,
-
             Battleship_,
             AircraftCarrier_,
             Destroyer_,
@@ -92,7 +87,12 @@ namespace screen {
             PrimaryMissMarker_,
             SecondaryHitMarker_,
             SecondaryMissMarker_,
-            SecondaryTarget_
+            SecondaryTarget_,
+
+            IdleSurrenderButton,
+            ActiveSurrenderButton,
+            IdleInstructionsButton,
+            ActiveInstructionsButton,
         };
         enum spriteNames {
             BackgroundDefault,
@@ -210,22 +210,7 @@ namespace screen {
          */
         static constexpr int sleepTimeMS = 400;
 
-
-//        sf::Texture primaryHitMarkerTexture;
-//        sf::Texture primaryMissMarkerTexture;
-//        sf::Texture secondaryHitMarkerTexture;
-//        sf::Texture secondaryMissMarkerTexture;
-//        sf::Texture idlePrimaryTargetTexture;
-//        sf::Texture activePrimaryTargetTexture;
-//        sf::Texture secondaryTargetTexture;
-//
-//
-//        sf::Sprite primaryHitMarkerSprite;
-//        sf::Sprite primaryMissMarkerSprite;
-//        sf::Sprite secondaryHitMarkerSprite;
-//        sf::Sprite secondaryMissMarkerSprite;
-//        sf::Sprite secondaryTargetSprite;
-
+        // TODO: Simplify
         vector<Target> targetVector;
 
         vector<sf::Sprite> primaryMarkersP1Vector;

--- a/src/screens/gameplay.hpp
+++ b/src/screens/gameplay.hpp
@@ -6,12 +6,12 @@
 #ifndef BATTLESHIP_GAMEPLAY_H
 #define BATTLESHIP_GAMEPLAY_H
 
+#include "../controllers/screenTemplate.hpp"
 #include "../entity/button.hpp"
 #include "../entity/coordinate.hpp"
 #include "../entity/grid.hpp"
-#include "../enums/shipNames.hpp"
 #include "../entity/target.hpp"
-#include "../controllers/screenTemplate.hpp"
+#include "../enums/shipNames.hpp"
 #include <SFML/System.hpp>
 #include <set>
 
@@ -425,6 +425,6 @@ namespace screen {
          */
         vector<sf::Sprite> secondaryMarkersP2Vector;
     };
-}// namespace screens
+}// namespace screen
 
 #endif// BATTLESHIP_GAMEPLAY_H

--- a/src/screens/gameplay.hpp
+++ b/src/screens/gameplay.hpp
@@ -1,6 +1,5 @@
 /**
- * File: gameplay.h
- * Description: Front-end class that defines the behaviour of the Gameplay screens
+ * Front-end class that defines the behaviour of the Gameplay screens
  */
 
 #ifndef BATTLESHIP_GAMEPLAY_H
@@ -20,6 +19,9 @@ using entity::Grid;
 using entity::SquareType;
 using entity::Target;
 using std::set;
+
+//Orientation of ships: Its name, top left coordinate and if it's horizontal
+typedef map<shipNames, tuple<Coordinate, bool>> shipOrientations;
 
 namespace screen {
     class Gameplay : public ScreenTemplate {
@@ -42,13 +44,12 @@ namespace screen {
         /**
          * Initializes P1 grid
          */
-         // TODO: take out the static part
-        static void setP1Grid(const map<shipNames, tuple<Coordinate, bool>> &ships);
+        void setP1Grid(const shipOrientations &ships);
 
         /**
          * Initializes P2 grid
          */
-        static void setP2Grid(const map<shipNames, tuple<Coordinate, bool>> &ships);
+        void setP2Grid(const shipOrientations &ships);
 
     private:
         // Singleton instance
@@ -105,22 +106,22 @@ namespace screen {
         /**
          * Map of P1 fleet layout
          */
-        static map<shipNames, tuple<Coordinate, bool>> fleetLayoutP1;
+        std::unique_ptr<shipOrientations> fleetLayoutP1;
 
         /**
          * Map of P2 fleet layout
          */
-        static map<shipNames, tuple<Coordinate, bool>> fleetLayoutP2;
+        std::unique_ptr<shipOrientations> fleetLayoutP2;
 
         /**
          * P1 Grid
          */
-        static Grid *gridP1;
+        std::unique_ptr<Grid> gridP1;
 
         /**
          * P2 Grid
          */
-        static Grid *gridP2;
+        std::unique_ptr<Grid> gridP2;
 
         /**
          * Set of grid coordinates used by environment
@@ -145,7 +146,7 @@ namespace screen {
         /**
          * Checks if the game is lost for a specified player (true: P1, false: P2)
          */
-        static bool lost(Grid &grid);
+        bool lost(Grid &grid);
 
         /**
          * Updates grid markers
@@ -165,7 +166,7 @@ namespace screen {
         /**
          * Sleeps the process (works for windows and unix-based systems)
          */
-        static void sleepMS();
+        void sleepMS();
 
         /**
          * Updates grid state
@@ -175,7 +176,7 @@ namespace screen {
         /**
          * Sets the fleet layout of the current player
          */
-        void setFleetLayout(map<shipNames, tuple<Coordinate, bool>> &fleetLayout);
+        void setFleetLayout(shipOrientations &fleetLayout);
 
         /**
          * Renders ship status

--- a/src/screens/homepage.cpp
+++ b/src/screens/homepage.cpp
@@ -19,7 +19,7 @@ Homepage &Homepage::getInstance() {
 
 Homepage::Homepage() {
     const vector<string> texturePaths{"homepage/HomepageBackground.png", "homepage/IdlePlayButton.png", "homepage/ActivePlayButton.png"};
-    this->images = ImagesManager(texturePaths, {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::Background}});
+    this->images = ScreenResourceManager(texturePaths, {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::Background}});
 
     this->playButton = std::make_unique<Button>(sf::Vector2f(232 * 5, 64 * 5), sf::Vector2f(5, 5),
                                                 images.getTexture(textureNames::IdlePlayButton),

--- a/src/screens/homepage.cpp
+++ b/src/screens/homepage.cpp
@@ -40,7 +40,7 @@ void Homepage::poll() {
                 gui.close();
                 break;
             case sf::Event::MouseButtonReleased:
-                if ((event.mouseButton.button == sf::Mouse::Left) && (resources.getButton(buttonNames::PlayButton).getButtonState())) {
+                if (event.mouseButton.button == sf::Mouse::Left && resources.getButton(buttonNames::PlayButton).getButtonState()) {
                     State::changeScreen(Screens::GAME_MODE_SELECTION);
                     break;
                 } else {

--- a/src/screens/homepage.cpp
+++ b/src/screens/homepage.cpp
@@ -20,7 +20,7 @@ Homepage &Homepage::getInstance() {
 Homepage::Homepage() {
     const vector<string> texturePaths{"homepage/HomepageBackground.png", "homepage/IdlePlayButton.png", "homepage/ActivePlayButton.png"};
     this->resources = ScreenResourceManager(texturePaths,
-                                            {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::Background}},
+                                            {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::Background_}},
                                             {{sf::Vector2f(232 * 5, 64 * 5), sf::Vector2f(5, 5),
                                               textureNames::IdlePlayButton, textureNames::ActivePlayButton}});
 }
@@ -56,7 +56,7 @@ void Homepage::render() {
     sf::RenderWindow &gui = *State::gui;
     gui.clear();
 
-    gui.draw(resources.getSprite(spriteNames::Backgrounds));
+    gui.draw(resources.getSprite(spriteNames::Background));
     resources.getButton(buttonNames::PlayButton).render(gui);
 
     if (State::getCurrentScreen() == Screens::HOMEPAGE) {

--- a/src/screens/homepage.cpp
+++ b/src/screens/homepage.cpp
@@ -17,12 +17,6 @@ Homepage &Homepage::getInstance() {
     return *instance;
 }
 
-void Homepage::run() {
-    this->update();
-    this->poll();
-    this->render();
-}
-
 Homepage::Homepage() {
     const vector<string> texturePaths{"homepage/HomepageBackground.png", "homepage/IdlePlayButton.png", "homepage/ActivePlayButton.png"};
     this->images = ImagesManager(texturePaths, {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::Background}});

--- a/src/screens/homepage.cpp
+++ b/src/screens/homepage.cpp
@@ -19,18 +19,15 @@ Homepage &Homepage::getInstance() {
 
 Homepage::Homepage() {
     const vector<string> texturePaths{"homepage/HomepageBackground.png", "homepage/IdlePlayButton.png", "homepage/ActivePlayButton.png"};
-    this->images = ScreenResourceManager(texturePaths,
-                                         {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::Background}},
-                                         1);
-
-    this->playButton = std::make_unique<Button>(sf::Vector2f(232 * 5, 64 * 5), sf::Vector2f(5, 5),
-                                                images.getTexture(textureNames::IdlePlayButton),
-                                                images.getTexture(textureNames::ActivePlayButton));
+    this->resources = ScreenResourceManager(texturePaths,
+                                            {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::Background}},
+                                            {{sf::Vector2f(232 * 5, 64 * 5), sf::Vector2f(5, 5),
+                                              textureNames::IdlePlayButton, textureNames::ActivePlayButton}});
 }
 
 void Homepage::update() {
     sf::Vector2f mousePosition = State::getMousePosition();
-    this->playButton->updateButtonState(mousePosition);
+    resources.getButton(buttonNames::PlayButton).updateButtonState(mousePosition);
 }
 
 void Homepage::poll() {
@@ -43,7 +40,7 @@ void Homepage::poll() {
                 gui.close();
                 break;
             case sf::Event::MouseButtonReleased:
-                if ((event.mouseButton.button == sf::Mouse::Left) && (this->playButton->getButtonState())) {
+                if ((event.mouseButton.button == sf::Mouse::Left) && (resources.getButton(buttonNames::PlayButton).getButtonState())) {
                     State::changeScreen(Screens::GAME_MODE_SELECTION);
                     break;
                 } else {
@@ -59,8 +56,8 @@ void Homepage::render() {
     sf::RenderWindow &gui = *State::gui;
     gui.clear();
 
-    gui.draw(images.getSprite(spriteNames::Backgrounds));
-    playButton->render(gui);
+    gui.draw(resources.getSprite(spriteNames::Backgrounds));
+    resources.getButton(buttonNames::PlayButton).render(gui);
 
     if (State::getCurrentScreen() == Screens::HOMEPAGE) {
         gui.display();

--- a/src/screens/homepage.cpp
+++ b/src/screens/homepage.cpp
@@ -19,7 +19,9 @@ Homepage &Homepage::getInstance() {
 
 Homepage::Homepage() {
     const vector<string> texturePaths{"homepage/HomepageBackground.png", "homepage/IdlePlayButton.png", "homepage/ActivePlayButton.png"};
-    this->images = ScreenResourceManager(texturePaths, {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::Background}});
+    this->images = ScreenResourceManager(texturePaths,
+                                         {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::Background}},
+                                         1);
 
     this->playButton = std::make_unique<Button>(sf::Vector2f(232 * 5, 64 * 5), sf::Vector2f(5, 5),
                                                 images.getTexture(textureNames::IdlePlayButton),

--- a/src/screens/homepage.hpp
+++ b/src/screens/homepage.hpp
@@ -46,8 +46,7 @@ namespace screen {
                             IdlePlayButton,
                             ActivePlayButton };
         enum spriteNames { Background };
-        enum buttonNames { PlayButton } ;
-
+        enum buttonNames { PlayButton };
     };
 }// namespace screen
 

--- a/src/screens/homepage.hpp
+++ b/src/screens/homepage.hpp
@@ -20,11 +20,6 @@ namespace screen {
         static Homepage &getInstance();
 
         /**
-         * Overridden run method of screenTemplate
-         */
-        void run() override;
-
-        /**
          * Copy constructor
          */
         Homepage(const Homepage &source) = delete;
@@ -46,9 +41,9 @@ namespace screen {
         Homepage();
 
         // SFML event loop helpers
-        void update();
-        void poll();
-        void render();
+        void update() override;
+        void poll() override;
+        void render() override;
 
         /**
          * Names to refer to the textures on this screen

--- a/src/screens/homepage.hpp
+++ b/src/screens/homepage.hpp
@@ -42,11 +42,17 @@ namespace screen {
         void render() override;
 
         // Names to refer to resources on this screen
-        enum textureNames { Background_,
-                            IdlePlayButton,
-                            ActivePlayButton };
-        enum spriteNames { Background };
-        enum buttonNames { PlayButton };
+        enum textureNames {
+            Background_,
+            IdlePlayButton,
+            ActivePlayButton
+        };
+        enum spriteNames {
+            Background
+        };
+        enum buttonNames {
+            PlayButton
+        };
     };
 }// namespace screen
 

--- a/src/screens/homepage.hpp
+++ b/src/screens/homepage.hpp
@@ -45,22 +45,13 @@ namespace screen {
         void poll() override;
         void render() override;
 
-        /**
-         * Names to refer to the textures on this screen
-         */
+        // Names to refer to resources on this screen
         enum textureNames { Background,
                             IdlePlayButton,
                             ActivePlayButton };
-
-        /**
-         * Names to refer to the sprites on this screen
-         */
         enum spriteNames { Backgrounds };
+        enum buttonNames { PlayButton } ;
 
-        /**
-         * Play button
-         */
-        std::unique_ptr<Button> playButton;
     };
 }// namespace screen
 

--- a/src/screens/homepage.hpp
+++ b/src/screens/homepage.hpp
@@ -30,14 +30,10 @@ namespace screen {
         Homepage &operator=(const Homepage &source) = delete;
 
     private:
-        /**
-         * Singleton instance
-         */
+        // Singleton instance
         static std::unique_ptr<Homepage> instance;
 
-        /**
-         * Singleton constructor
-         */
+        // Singleton constructor
         Homepage();
 
         // SFML event loop helpers
@@ -46,10 +42,10 @@ namespace screen {
         void render() override;
 
         // Names to refer to resources on this screen
-        enum textureNames { Background,
+        enum textureNames { Background_,
                             IdlePlayButton,
                             ActivePlayButton };
-        enum spriteNames { Backgrounds };
+        enum spriteNames { Background };
         enum buttonNames { PlayButton } ;
 
     };

--- a/src/screens/instructions.cpp
+++ b/src/screens/instructions.cpp
@@ -8,21 +8,26 @@
 
 using screen::Instructions;
 
-Instructions *Instructions::instance = nullptr;
+std::unique_ptr<Instructions> Instructions::instance = nullptr;
+
+Instructions &screen::Instructions::getInstance() {
+    if (instance == nullptr) {
+        instance.reset(new Instructions);
+    }
+    return *instance;
+}
 
 Instructions::Instructions() : ScreenTemplate() {
-    loadTexture(this->instructionsBackgroundTexture, "instructions/InstructionsBackground.png");
-    loadTexture(this->idleBackButtonTexture, "instructions/IdleBackButton.png");
-    loadTexture(this->activeBackButtonTexture, "instructions/ActiveBackButton.png");
+    const vector<string> texturePaths{"instructions/InstructionsBackground.png", "instructions/IdleBackButton.png", "instructions/ActiveBackButton.png"};
 
-    setSprite(sf::Vector2f(0, 0), sf::Vector2f(5, 5), this->instructionsBackgroundTexture, this->backgroundSprite);
-
-    this->backButton = new Button(sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), this->idleBackButtonTexture, this->activeBackButtonTexture);
+    this->resources = ScreenResourceManager(texturePaths,
+                                            {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::Background_}},
+                                            {{sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleBackButton, textureNames::ActiveBackButton}});
 }
 
 void Instructions::update() {
     sf::Vector2f mousePosition = State::getMousePosition();
-    this->backButton->updateButtonState(mousePosition);
+    resources.getButton(buttonNames::BackButton).updateButtonState(mousePosition);
 }
 
 void Instructions::poll() {
@@ -37,7 +42,7 @@ void Instructions::poll() {
                 break;
 
             case sf::Event::MouseButtonReleased:
-                if ((event.mouseButton.button == sf::Mouse::Left) && (this->backButton->getButtonState())) {
+                if (event.mouseButton.button == sf::Mouse::Left && resources.getButton(buttonNames::BackButton).getButtonState()) {
                     State::previousScreen();
                     break;
                 } else {
@@ -54,17 +59,10 @@ void Instructions::render() {
     sf::RenderWindow &gui = *State::gui;
     gui.clear();
 
-    gui.draw(this->backgroundSprite);
-    backButton->render(gui);
+    gui.draw(resources.getSprite(spriteNames::Background));
+    resources.getButton(buttonNames::BackButton).render(gui);
 
     if (State::getCurrentScreen() == Screens::INSTRUCTIONS) {
         gui.display();
     }
-}
-
-Instructions &screen::Instructions::getInstance() {
-    if (instance == nullptr) {
-        instance = new Instructions;
-    }
-    return *instance;
 }

--- a/src/screens/instructions.cpp
+++ b/src/screens/instructions.cpp
@@ -62,12 +62,6 @@ void Instructions::render() {
     }
 }
 
-void Instructions::run() {
-    this->update();
-    this->poll();
-    this->render();
-}
-
 Instructions &screen::Instructions::getInstance() {
     if (instance == nullptr) {
         instance = new Instructions;

--- a/src/screens/instructions.cpp
+++ b/src/screens/instructions.cpp
@@ -4,7 +4,6 @@
  */
 
 #include "instructions.hpp"
-#include "../helpers/helperFunctions.hpp"
 
 using screen::Instructions;
 
@@ -19,10 +18,10 @@ Instructions &screen::Instructions::getInstance() {
 
 Instructions::Instructions() : ScreenTemplate() {
     const vector<string> texturePaths{"instructions/InstructionsBackground.png", "instructions/IdleBackButton.png", "instructions/ActiveBackButton.png"};
-
     this->resources = ScreenResourceManager(texturePaths,
                                             {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::Background_}},
-                                            {{sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5), textureNames::IdleBackButton, textureNames::ActiveBackButton}});
+                                            {{sf::Vector2f(352 * 5, 12 * 5), sf::Vector2f(5, 5),
+                                              textureNames::IdleBackButton, textureNames::ActiveBackButton}});
 }
 
 void Instructions::update() {

--- a/src/screens/instructions.hpp
+++ b/src/screens/instructions.hpp
@@ -8,7 +8,6 @@
 
 #include "../controllers/screenTemplate.hpp"
 #include "../entity/button.hpp"
-
 #include <SFML/System.hpp>
 
 using entity::Button;
@@ -48,8 +47,7 @@ namespace screen {
                             IdleBackButton,
                             ActiveBackButton };
         enum spriteNames { Background };
-        enum buttonNames { BackButton } ;
-
+        enum buttonNames { BackButton };
     };
 }// namespace screen
 

--- a/src/screens/instructions.hpp
+++ b/src/screens/instructions.hpp
@@ -82,10 +82,6 @@ namespace screen {
          */
         Instructions &operator=(const Instructions &source) = delete;
 
-        /**
-         * Overridden run method of screenTemplate
-         */
-        void run() override;
     };
 }// namespace screens
 

--- a/src/screens/instructions.hpp
+++ b/src/screens/instructions.hpp
@@ -43,11 +43,17 @@ namespace screen {
         void render() override;
 
         // Names to refer to resources on this screen
-        enum textureNames { Background_,
-                            IdleBackButton,
-                            ActiveBackButton };
-        enum spriteNames { Background };
-        enum buttonNames { BackButton };
+        enum textureNames {
+            Background_,
+            IdleBackButton,
+            ActiveBackButton
+        };
+        enum spriteNames {
+            Background
+        };
+        enum buttonNames {
+            BackButton
+        };
     };
 }// namespace screen
 

--- a/src/screens/instructions.hpp
+++ b/src/screens/instructions.hpp
@@ -6,8 +6,8 @@
 #ifndef BATTLESHIP_INSTRUCTIONS_H
 #define BATTLESHIP_INSTRUCTIONS_H
 
-#include "../entity/button.hpp"
 #include "../controllers/screenTemplate.hpp"
+#include "../entity/button.hpp"
 
 #include <SFML/System.hpp>
 
@@ -15,57 +15,6 @@ using entity::Button;
 
 namespace screen {
     class Instructions : public ScreenTemplate {
-    private:
-        /**
-         * Background texture
-         */
-        sf::Texture instructionsBackgroundTexture;
-
-        /**
-         * Idle back button texture
-         */
-        sf::Texture idleBackButtonTexture;
-
-        /**
-         * Active back button texture
-         */
-        sf::Texture activeBackButtonTexture;
-
-        /**
-         * Background sprite
-         */
-        sf::Sprite backgroundSprite;
-
-        /**
-         * Back button 
-         */
-        Button *backButton;
-
-        /**
-         * Calls helpers::updateMousePosition() and entity::Button::updateButtonState()
-         */
-        void update();
-
-        /**
-         * Polls for system events
-         */
-        void poll();
-
-        /**
-         * Renders all sprites
-         */
-        void render();
-
-        /**
-         * Constructor
-         */
-        Instructions();
-
-        /**
-         *
-         */
-        static Instructions *instance;
-
     public:
         /**
          *
@@ -82,7 +31,26 @@ namespace screen {
          */
         Instructions &operator=(const Instructions &source) = delete;
 
+    private:
+        // Singleton instance
+        static std::unique_ptr<Instructions> instance;
+
+        // Singleton constructor
+        Instructions();
+
+        // SFML event loop helpers
+        void update() override;
+        void poll() override;
+        void render() override;
+
+        // Names to refer to resources on this screen
+        enum textureNames { Background_,
+                            IdleBackButton,
+                            ActiveBackButton };
+        enum spriteNames { Background };
+        enum buttonNames { BackButton } ;
+
     };
-}// namespace screens
+}// namespace screen
 
 #endif// BATTLESHIP_INSTRUCTIONS_H

--- a/src/screens/intermediary.cpp
+++ b/src/screens/intermediary.cpp
@@ -1,30 +1,33 @@
 /**
- * File: intermediary.cpp
- * Description: Front-end class that defines the behaviour of the Intermediary screens
+ * Front-end class that defines the behaviour of the Intermediary screens
  */
 
 #include "intermediary.hpp"
-#include "../helpers/helperFunctions.hpp"
 
 using screen::Intermediary;
 
-Intermediary *Intermediary::instance = nullptr;
+std::unique_ptr<Intermediary> Intermediary::instance = nullptr;
+
+Intermediary &screen::Intermediary::getInstance() {
+    if (instance == nullptr) {
+        instance.reset(new Intermediary());
+    }
+    return *instance;
+}
 
 Intermediary::Intermediary() : ScreenTemplate() {
-    loadTexture(this->intermediaryP1BackgroundTexture, "intermediary/IntermediaryP1Background.png");
-    loadTexture(this->intermediaryP2BackgroundTexture, "intermediary/IntermediaryP2Background.png");
-    loadTexture(this->idleContinueButtonTexture, "intermediary/IdleContinueButton.png");
-    loadTexture(this->activeContinueButtonTexture, "intermediary/ActiveContinueButton.png");
-
-    setSprite(sf::Vector2f(0, 0), sf::Vector2f(5, 5), this->intermediaryP1BackgroundTexture, this->backgroundP1Sprite);
-    setSprite(sf::Vector2f(0, 0), sf::Vector2f(5, 5), this->intermediaryP2BackgroundTexture, this->backgroundP2Sprite);
-
-    this->continueButton = new Button(sf::Vector2f(144 * 5, 108 * 5), sf::Vector2f(5, 5), this->idleContinueButtonTexture, this->activeContinueButtonTexture);
+    const vector<string> texturePaths{"intermediary/IntermediaryP1Background.png", "intermediary/IntermediaryP2Background.png",
+                                      "intermediary/IdleContinueButton.png", "intermediary/ActiveContinueButton.png"};
+    this->resources = ScreenResourceManager(texturePaths,
+                                            {{sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::IntermediaryP1Background},
+                                             {sf::Vector2f(0, 0), sf::Vector2f(5, 5), textureNames::IntermediaryP2Background}},
+                                            {{sf::Vector2f(144 * 5, 108 * 5), sf::Vector2f(5, 5),
+                                              textureNames::IdleContinueButton, textureNames::ActiveContinueButton}});
 }
 
 void Intermediary::update() {
     sf::Vector2f mousePosition = State::getMousePosition();
-    this->continueButton->updateButtonState(mousePosition);
+    resources.getButton(buttonNames::ContinueButton).updateButtonState(mousePosition);
 }
 
 void Intermediary::poll() {
@@ -33,30 +36,19 @@ void Intermediary::poll() {
 
     while (gui.pollEvent(event)) {
         switch (event.type) {
-
             case sf::Event::Closed:
                 gui.close();
                 break;
-
             case sf::Event::MouseButtonReleased:
-                if ((event.mouseButton.button == sf::Mouse::Left) && (this->continueButton->getButtonState())) {
-                    if ((State::player == State::Player::P2) && (State::getPreviousScreen() == Screens::FLEET_PLACEMENT)) {
+                if (event.mouseButton.button == sf::Mouse::Left && resources.getButton(buttonNames::ContinueButton).getButtonState()) {
+                    if (State::player == State::Player::P2 && State::getPreviousScreen() == Screens::FLEET_PLACEMENT) {
                         State::changeScreen(Screens::FLEET_PLACEMENT);
                         break;
-                    } else if ((State::player == State::Player::P1) && (State::getPreviousScreen() == Screens::FLEET_PLACEMENT)) {
-                        State::changeScreen(Screens::GAMEPLAY);
-                        break;
-                    } else if ((State::player == State::Player::P2) && (State::getPreviousScreen() == Screens::GAMEPLAY)) {
-                        State::changeScreen(Screens::GAMEPLAY);
-                        break;
-                    } else if ((State::player == State::Player::P1) && (State::getPreviousScreen() == Screens::GAMEPLAY)) {
-                        State::changeScreen(Screens::GAMEPLAY);
-                        break;
                     } else {
+                        State::changeScreen(Screens::GAMEPLAY);
                         break;
                     }
                 }
-
             default:
                 break;
         }
@@ -68,20 +60,13 @@ void Intermediary::render() {
     gui.clear();
 
     if (State::player == State::Player::P2) {
-        gui.draw(this->backgroundP2Sprite);
+        gui.draw(resources.getSprite(spriteNames::BackgroundP2));
     } else {
-        gui.draw(this->backgroundP1Sprite);
+        gui.draw(resources.getSprite(spriteNames::BackgroundP1));
     }
-    continueButton->render(gui);
+    resources.getButton(buttonNames::ContinueButton).render(gui);
 
     if (State::getCurrentScreen() == Screens::INTERMEDIARY) {
         gui.display();
     }
-}
-
-Intermediary &screen::Intermediary::getInstance() {
-    if (instance == nullptr) {
-        instance = new Intermediary();
-    }
-    return *instance;
 }

--- a/src/screens/intermediary.cpp
+++ b/src/screens/intermediary.cpp
@@ -79,12 +79,6 @@ void Intermediary::render() {
     }
 }
 
-void Intermediary::run() {
-    this->update();
-    this->poll();
-    this->render();
-}
-
 Intermediary &screen::Intermediary::getInstance() {
     if (instance == nullptr) {
         instance = new Intermediary();

--- a/src/screens/intermediary.hpp
+++ b/src/screens/intermediary.hpp
@@ -92,10 +92,6 @@ namespace screen {
          */
         Intermediary &operator=(const Intermediary &source) = delete;
 
-        /**
-         * Overridden run method of screenTemplate
-         */
-        void run() override;
     };
 }// namespace screens
 

--- a/src/screens/intermediary.hpp
+++ b/src/screens/intermediary.hpp
@@ -1,81 +1,18 @@
 /**
- * File: intermediary.h
- * Description: Front-end class that defines the behaviour of the Intermediary screens
+ * Front-end class that defines the behaviour of the Intermediary screens
  */
 
 #ifndef BATTLESHIP_INTERMEDIARY_H
 #define BATTLESHIP_INTERMEDIARY_H
 
-#include "../entity/button.hpp"
 #include "../controllers/screenTemplate.hpp"
-
+#include "../entity/button.hpp"
 #include <SFML/System.hpp>
 
 using entity::Button;
 
 namespace screen {
     class Intermediary : public ScreenTemplate {
-    private:
-        /**
-         * P1 background texture
-         */
-        sf::Texture intermediaryP1BackgroundTexture;
-
-        /**
-         * P2 background texture
-         */
-        sf::Texture intermediaryP2BackgroundTexture;
-
-        /**
-         * Idle continue button texture
-         */
-        sf::Texture idleContinueButtonTexture;
-
-        /**
-         * Active continue button texture
-         */
-        sf::Texture activeContinueButtonTexture;
-
-        /**
-         * Background P1 sprite
-         */
-        sf::Sprite backgroundP1Sprite;
-
-        /**
-         * Background P2 sprite
-         */
-        sf::Sprite backgroundP2Sprite;
-
-        /**
-         * Continue button 
-         */
-        Button *continueButton;
-
-        /**
-         * Calls helpers::updateMousePosition() and entity::Button::updateButtonState()
-         */
-        void update();
-
-        /**
-         * Polls for system events
-         */
-        void poll();
-
-        /**
-         * Renders all sprites
-         */
-        void render();
-
-        /**
-         *
-         */
-        static Intermediary *instance;
-
-        /**
-         * Constructor
-         */
-        Intermediary();
-
     public:
         /**
          *
@@ -92,7 +29,27 @@ namespace screen {
          */
         Intermediary &operator=(const Intermediary &source) = delete;
 
+    private:
+        // Singleton instance
+        static std::unique_ptr<Intermediary> instance;
+
+        // Singleton constructor
+        Intermediary();
+
+        // SFML event loop helpers
+        void update() override;
+        void poll() override;
+        void render() override;
+
+        // Names to refer to resources on this screen
+        enum textureNames { IntermediaryP1Background,
+                            IntermediaryP2Background,
+                            IdleContinueButton,
+                            ActiveContinueButton };
+        enum spriteNames { BackgroundP1,
+                           BackgroundP2 };
+        enum buttonNames { ContinueButton };
     };
-}// namespace screens
+}// namespace screen
 
 #endif// BATTLESHIP_INTERMEDIARY_H

--- a/src/screens/intermediary.hpp
+++ b/src/screens/intermediary.hpp
@@ -42,13 +42,19 @@ namespace screen {
         void render() override;
 
         // Names to refer to resources on this screen
-        enum textureNames { IntermediaryP1Background,
-                            IntermediaryP2Background,
-                            IdleContinueButton,
-                            ActiveContinueButton };
-        enum spriteNames { BackgroundP1,
-                           BackgroundP2 };
-        enum buttonNames { ContinueButton };
+        enum textureNames {
+            IntermediaryP1Background,
+            IntermediaryP2Background,
+            IdleContinueButton,
+            ActiveContinueButton
+        };
+        enum spriteNames {
+            BackgroundP1,
+            BackgroundP2
+        };
+        enum buttonNames {
+            ContinueButton
+        };
     };
 }// namespace screen
 

--- a/test/assertions.hpp
+++ b/test/assertions.hpp
@@ -5,17 +5,17 @@
 #ifndef BATTLESHIP_ASSERTIONS_H
 #define BATTLESHIP_ASSERTIONS_H
 
-#define ASSERT(statement)                                                         \
-    {                                                                             \
-        if (!statement) {                                                         \
-            std::string path = __FILE__;                                          \
-            std::stringstream errMsg;                                             \
-            errMsg << "\n\nASSERT FAILED: " << #statement << std::endl            \
-                   << "Value: " << statement << std::endl                         \
+#define ASSERT(statement)                                                        \
+    {                                                                            \
+        if (!statement) {                                                        \
+            std::string path = __FILE__;                                         \
+            std::stringstream errMsg;                                            \
+            errMsg << "\n\nASSERT FAILED: " << #statement << std::endl           \
+                   << "Value: " << statement << std::endl                        \
                    << "Location: " << path.substr(path.find("battleship\\test")) \
-                   << " (line " << __LINE__ << ")" << std::endl;                  \
-            throw std::invalid_argument(errMsg.str());                            \
-        }                                                                         \
+                   << " (line " << __LINE__ << ")" << std::endl;                 \
+            throw std::invalid_argument(errMsg.str());                           \
+        }                                                                        \
     }
 
 #define ASSERT_OPERATION(left, operator, right)                                                       \
@@ -25,7 +25,7 @@
             std::stringstream errMsg;                                                                 \
             errMsg << "\n\nASSERT FAILED: " << #left << " " << #operator<< " " << #right << std::endl \
                    << "Value: " << left << " " << #operator<< " " << right << std::endl               \
-                   << "Location: " << path.substr(path.find("battleship/test"))                      \
+                   << "Location: " << path.substr(path.find("battleship/test"))                       \
                    << " (line " << __LINE__ << ")" << std::endl;                                      \
             throw std::invalid_argument(errMsg.str());                                                \
         }                                                                                             \

--- a/test/unit/ScreenTemplate.cpp
+++ b/test/unit/ScreenTemplate.cpp
@@ -10,31 +10,31 @@ using screen::ScreenTemplate;
 /**
 * Dummy base class to test abstract class 'functionality'
 */
-class DummyScreen : screen::ScreenTemplate {
-public:
-    static DummyScreen &getInstance() {
-        if (instance == nullptr) {
-            instance = new DummyScreen();
-        }
-        return *instance;
-    }
-
-    // Dummy methods
-    void run() override {}
-
-    // Needed for dynamic memory
-    DummyScreen(const DummyScreen &other) = delete;
-    DummyScreen &operator=(const DummyScreen &rhs) = delete;
-
-private:
-    DummyScreen() = default;
-    static DummyScreen *instance;
-};
-
-DummyScreen *DummyScreen::instance = nullptr;
-
-TEST(unit, screenTemplate) {
-    // These test are mainly to understand base class implementation
-    // and ensure the abstract class has a proper implementation
-    DummyScreen &testScreen = DummyScreen::getInstance();
-}
+//class DummyScreen : screen::ScreenTemplate {
+//public:
+//    static DummyScreen &getInstance() {
+//        if (instance == nullptr) {
+//            instance = new DummyScreen();
+//        }
+//        return *instance;
+//    }
+//
+//    // Dummy methods
+//    void run() override {}
+//
+//    // Needed for dynamic memory
+//    DummyScreen(const DummyScreen &other) = delete;
+//    DummyScreen &operator=(const DummyScreen &rhs) = delete;
+//
+//private:
+//    DummyScreen() = default;
+//    static DummyScreen *instance;
+//};
+//
+//DummyScreen *DummyScreen::instance = nullptr;
+//
+//TEST(unit, screenTemplate) {
+//    // These test are mainly to understand base class implementation
+//    // and ensure the abstract class has a proper implementation
+//    DummyScreen &testScreen = DummyScreen::getInstance();
+//}


### PR DESCRIPTION
For screens, the textures, sprites and buttons are moved to resource managers to greatly simplify each excessively bulky screen class